### PR TITLE
Removal of uppercase string format from metdata reference

### DIFF
--- a/src/components/metadata/metadataReference.js
+++ b/src/components/metadata/metadataReference.js
@@ -13,7 +13,6 @@ import MetadataDetail from './metadataDetail';
 
 // Styles
 import compStyles from './metadataReference.module.css';
-import * as StringFormat from '../../utils/string-format.service';
 
 class MetadataReference extends React.Component {
 
@@ -29,7 +28,7 @@ class MetadataReference extends React.Component {
 					description={description}
 					groupRef={true}
 					isRequired={elementRefRequired}
-					label={user_friendly ? user_friendly : StringFormat.convertSentenceCasetoTitleCase(name.replace(regex, ' '))}
+					label={user_friendly ? user_friendly : name.replace(regex, ' ')}
 					type={elementType}/> : null}
 			</div>
 		);

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -6,7 +6,6 @@
  */
 
 // Core dependencies
-import { navigate } from "gatsby"
 import Link from 'gatsby-link';
 import React from 'react';
 


### PR DESCRIPTION
- for consistency, the uppercase string format on the metadata reference (RHS) has been removed...
