### PR TITLE
Add 2nd level to TOC outline - Fix H1, H2, H3 headings for proper outlining. Resolves #456.

### DIFF
--- a/src/components/analyze/analysisDetail.js
+++ b/src/components/analyze/analysisDetail.js
@@ -22,17 +22,13 @@ class AnalysisDetail extends React.Component {
 			<div>
 				<div className={compStyles.hcaAnalyzeDetail}>
 					<div>
-						<div>
-							<h2>{this.props.data.frontmatter.title}</h2>
-							<p className={classNames(fontStyles.xs, compStyles.author)}>{this.props.data.frontmatter.author}</p>
-							<a href={this.props.data.frontmatter.githubUrl} target='_blank' rel='noopener noreferrer'
-							   className={classNames(globalStyles.button, globalStyles.outline, globalStyles.primary, compStyles.view)}>View</a>
-							<div dangerouslySetInnerHTML={{__html: this.props.data.html}}/>
-						</div>
+						<h1 className={globalStyles.md}>{this.props.data.frontmatter.title}</h1>
+						<p className={classNames(fontStyles.s, compStyles.author)}>{this.props.data.frontmatter.author}</p>
 					</div>
 					<a href={this.props.data.frontmatter.githubUrl} target='_blank' rel='noopener noreferrer'
 					   className={classNames(globalStyles.button, globalStyles.outline, globalStyles.primary, compStyles.view)}>View</a>
 				</div>
+				<div dangerouslySetInnerHTML={{__html: this.props.data.html}}/>
 				<a className={classNames(globalStyles.editContent, globalStyles.editContentSeparator)}
 				   href={this.props.editPath} target='_blank' rel='noopener noreferrer'>Improve this page</a>
 			</div>

--- a/src/components/analyze/analysisDetail.module.css
+++ b/src/components/analyze/analysisDetail.module.css
@@ -9,27 +9,23 @@
 /* Analyze list */
 .hcaAnalyzeDetail {
 	display: flex;
-	justify-content: space-between;
-	position: relative; /* Positions button */
+	flex-direction: column;
 	width: 100%;
 }
 
-/* Heading */
-.hcaAnalyzeDetail div h2:first-child {
-	margin: 0;
+/* Title, author container */
+.hcaAnalyzeDetail > div {
+	max-width: 540px;
 }
 
 /* Author */
 .hcaAnalyzeDetail .author {
-	margin-bottom: 24px;
+	color: var(--gray-darkest);
+	margin: -14px 0 24px;
 }
 
-/* Hide view button - positioned RHS */
-.hcaAnalyzeDetail > .view {
-	display: none;
-}
-
-.hcaAnalyzeDetail a + div {
+/* Markdown */
+.hcaAnalyzeDetail + div {
 	margin-top: 24px;
 }
 
@@ -39,21 +35,19 @@
  */
 @media screen and (min-width: 1024px) {
 
+	/* Analyze list */
+	.hcaAnalyzeDetail {
+		flex-direction: row;
+		justify-content: space-between;
+	}
+
+	/* Title, author container */
 	.hcaAnalyzeDetail > div {
 		margin-right: 16px;
 	}
 
-	/* Show view button - positioned RHS */
-	.hcaAnalyzeDetail > .view {
-		display: flex;
-	}
-
-	/* Hide view button - positioned below author */
-	.hcaAnalyzeDetail > div .view {
-		display: none;
-	}
-
-	.hcaAnalyzeDetail a + div {
+	/* Markdown */
+	.hcaAnalyzeDetail + div {
 		margin-top: 0;
 	}
 }

--- a/src/components/hcaContent/hcaContent.module.css
+++ b/src/components/hcaContent/hcaContent.module.css
@@ -21,10 +21,6 @@
 	z-index: 2; /* Required for heading anchor */
 }
 
-.hcaContentInner > h2:first-of-type {
-	margin-top: 0;
-}
-
 /**
  * HCA specific breakpoint
  */

--- a/src/components/hcaMain/hcaMain.js
+++ b/src/components/hcaMain/hcaMain.js
@@ -15,6 +15,7 @@ import Section from '../section/section';
 import TabNav from '../tabNav/tabNav';
 
 // Styles
+import compStyles from './hcaMain.module.css';
 import globalStyles from '../../styles/global.module.css';
 
 class HCAMain extends React.Component {
@@ -25,7 +26,7 @@ class HCAMain extends React.Component {
 			<div className={globalStyles.pageWrapper}>
 				<Section docPath={docPath} sectionTitle={sectionTitle}/>
 				<TabNav docPath={docPath} homeTab={homeTab} noTab={noTab}/>
-				<div style={{position: 'relative'}}>
+				<div className={compStyles.main}>
 					<div className={globalStyles.wrapper}>
 						<HCAContent docPath={docPath} noNav={noNav}>{children}</HCAContent>
 					</div>

--- a/src/components/hcaMain/hcaMain.module.css
+++ b/src/components/hcaMain/hcaMain.module.css
@@ -1,0 +1,12 @@
+/*
+ * Human Cell Atlas
+ * https://www.humancellatlas.org/
+ *
+ * Style definitions specific to the HCA Data Portal main component.
+ */
+
+/* Main */
+.main {
+    flex: 1;
+    position: relative; /* Positions cell image for error and 404 page */
+}

--- a/src/components/toc/toc.js
+++ b/src/components/toc/toc.js
@@ -33,7 +33,7 @@ class TOC extends React.Component {
 
 	getAnchor = (heading) => {
 
-		let specialCharacters = /[:?.,]/g,
+		let specialCharacters = /[:?.,()]/g,
 			whiteSpace = /\s/g;
 
 		return heading.replace(whiteSpace, '-').replace(specialCharacters, '').toLowerCase();
@@ -77,7 +77,7 @@ class TOC extends React.Component {
 export default (props) => {
 
 	let docPath = props.docPath,
-		pagesTOC = TOCSiteMap(docPath) ? TOCSiteMap(docPath).headings.slice(1).filter(heading => heading.depth <= 3) : '',
+		pagesTOC = TOCSiteMap(docPath) ? TOCSiteMap(docPath).headings.filter(heading => heading.depth > 1 && heading.depth <= 3) : '',
 		metaNav = docPath.includes('/metadata/dictionary/'),
 		docPathSplitByPath = docPath.split('/'),
 		docPathSplitByPathLength = docPathSplitByPath.length - 1,

--- a/src/components/toc/toc.module.css
+++ b/src/components/toc/toc.module.css
@@ -36,7 +36,7 @@
 
 /* TOC - depth 3 */
 .tocs li a.depth3 {
-	//margin-left: 8px;
+	margin-left: 8px;
 }
 
 /* TOC link - hover */

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -15,11 +15,12 @@ import Layout from '../components/layout';
 // Styles
 import compStyles from './error.module.css';
 import fontStyles from '../styles/fontsize.module.css';
+import globalStyles from '../styles/global.module.css';
 
 const NotFoundPage = () => (
 	<Layout homeTab={true} noNav={true} sectionTitle={'Page Not Found'}>
 		<div className={compStyles.cellImage}/>
-		<h2>Oops!</h2>
+		<h1 className={globalStyles.md}>Oops!</h1>
 		<p className={fontStyles.m}>We can’t find the page you were looking for.</p>
 		<p className={fontStyles.m}>Here are some helpful links instead:</p>
 		<p><Link to='/'>Home Page</Link></p>

--- a/src/pages/error.js
+++ b/src/pages/error.js
@@ -14,11 +14,12 @@ import Layout from '../components/layout';
 // Styles
 import compStyles from './error.module.css';
 import fontStyles from '../styles/fontsize.module.css';
+import globalStyles from '../styles/global.module.css';
 
 const ErrorPage = () => (
 	<Layout homeTab={false} noNav={true} noTab={true} sectionTitle={'Error'}>
 		<div className={compStyles.cellImage}/>
-		<h2>Oops!</h2>
+		<h1 className={globalStyles.md}>Oops!</h1>
 		<p className={fontStyles.m}>An error has occurred processing your request.</p>
 	</Layout>
 );

--- a/src/pages/error.module.css
+++ b/src/pages/error.module.css
@@ -10,17 +10,11 @@
 	background: url(../../images/data-portal/cell.png) center no-repeat;
 	background-size: cover;
 	bottom: 0;
-	height: 100vh;
 	left: 0;
 	position: absolute;
 	right: 0;
 	top: 0;
 	z-index: -1;
-}
-
-/* Error h2 */
-.error h2 {
-	margin: 0 0 16px;
 }
 
 .error a:not(:last-of-type) {

--- a/src/styles/global.module.css
+++ b/src/styles/global.module.css
@@ -5,7 +5,9 @@
 
 /* Page wrapper */
 .pageWrapper {
+	display: flex; /* Required for 404 and error cell image */
 	flex: 1;
+	flex-direction: column;
 }
 
 /* Banner wrapper */
@@ -34,14 +36,11 @@
 	margin-bottom: 4px;
 }
 
-.md > h1:first-of-type {
-	font-size: 24px;
-	line-height: 30px;
-	margin-top: 0;
-}
-
-.md > h2:first-of-type {
-	margin-top: 0;
+/* <h1> - overrides h1 specification for markdown content */
+.md > h1, h1.md {
+	font-size: 30px;
+	line-height: 36px;
+	margin: 0 0 18px;
 }
 
 /* Button - class "button" */

--- a/src/templates/metadataTemplate.js
+++ b/src/templates/metadataTemplate.js
@@ -35,7 +35,7 @@ export default function Template({data}) {
 
 	return (
 		<Layout pageTitle={pageTitle} docPath={docPath}>
-			<h2 className={classNames(globalStyles.md, compStyles.meta)}>{pageTitle}</h2>
+			<h1 className={classNames(globalStyles.md, compStyles.meta)}>{pageTitle}</h1>
 			<p className={fontStyles.hcaCode}>{type.name}</p>
 			<p className={fontStyles.l}>{type.description}</p>
 			<p className={fontStyles.xxs}>* Indicates a required field</p>

--- a/src/templates/metadataTemplate.module.css
+++ b/src/templates/metadataTemplate.module.css
@@ -8,7 +8,7 @@
 /* Type */
 .meta + p {
 	font-size: 15px;
-	margin: 4px 0;
+	margin: -18px 0 4px;
 }
 
 /* Description */

--- a/src/templates/systemStatusTemplate.js
+++ b/src/templates/systemStatusTemplate.js
@@ -16,6 +16,7 @@ import Layout from '../components/layout';
 // Styles
 import compStyles from './systemStatusTemplate.module.css';
 import fontStyles from '../styles/fontsize.module.css';
+import globalStyles from '../styles/global.module.css';
 
 let classNames = require('classnames');
 
@@ -50,7 +51,7 @@ export default function Template({data}) {
 
 	return (
 		<Layout sectionTitle={'System Status'} homeTab={false} noTab={true} noNav={true}>
-			<h2>Environment - {displayEnv}</h2>
+			<h1 className={globalStyles.md}>Environment - {displayEnv}</h1>
 			<div className={compStyles.system}>
 				<div className={classNames(fontStyles.m, compStyles.label)}>
 					<span>System Name</span>

--- a/src/utils/typography.js
+++ b/src/utils/typography.js
@@ -100,6 +100,9 @@ const typography = new Typography({
 				margin: 0,
 				padding: 0,
 			},
+			'ol, ul': {
+				marginBottom: '24px',
+			},
 			img: {
 				border: 0,
 				marginBottom: 0,


### PR DESCRIPTION
Includes:
- fix for error and 404 pages -> cell image and footer borked (see below image).
- fix for section `Analysis Tools Registry` TOC -> the component `analysisDetail.js` required a html structure rework to fix borked TOC... see https://dev.data.humancellatlas.org/analyze/methods/slingshot

![image](https://user-images.githubusercontent.com/18710366/62180698-5854e080-b394-11e9-8d0c-920ae4df0eb7.png)

