### PR TITLE
Add `orange` label to new issues

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,10 @@
+name: Add `orange` label to new issues
+on: [issues]
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: HumanCellAtlas/azul-github-labeler-action@releases/v1
+      with:
+        repo-token: "${{secrets.GITHUB_TOKEN}}"
+        label: orange


### PR DESCRIPTION
This uses a Github action to label new issues orange.

Source is here: https://github.com/HumanCellAtlas/azul-github-labeler-action/blob/master/src/main.ts