### PR TITLE
Switched banners from using cookies to local storage #1703

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11044,11 +11044,6 @@
         }
       }
     },
-    "js-cookie": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.1.tgz",
-      "integrity": "sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw=="
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "gatsby-transformer-json": "^3.14.0",
     "gatsby-transformer-remark": "^4.10.0",
     "gatsby-transformer-yaml": "^3.14.0",
-    "js-cookie": "^3.0.1",
     "katex": "^0.13.24",
     "lunr": "^2.3.9",
     "normalize.css": "^8.0.1",

--- a/src/components/banner/banner.js
+++ b/src/components/banner/banner.js
@@ -44,10 +44,13 @@ class Banner extends React.Component {
           ) : null
         ) : null}
         {this.props.position === "top" && this.isTestEnvironment() ? (
-          <Environment cookieName="environmentAccepted" message={testMessage} />
+          <Environment
+            localStorageName="environmentAccepted"
+            message={testMessage}
+          />
         ) : null}
         {this.props.position === "bottom" ? (
-          <Privacy cookieName="privacyAccepted" />
+          <Privacy localStorageName="privacyAccepted" />
         ) : null}
       </div>
     );

--- a/src/components/banner/environment.js
+++ b/src/components/banner/environment.js
@@ -6,7 +6,6 @@
  */
 
 // Core dependencies
-import Cookies from "js-cookie";
 import React from "react";
 
 // App dependencies
@@ -28,21 +27,21 @@ class Environment extends React.Component {
   }
 
   componentDidMount() {
-    const { cookieName } = this.props;
+    const { localStorageName } = this.props;
 
-    if (Cookies.get(cookieName) === undefined) {
+    if (localStorage.getItem(localStorageName) === null) {
       this.setState({ visible: true });
     }
 
-    if (Cookies.get(cookieName) === true) {
+    if (localStorage.getItem(localStorageName) === "T") {
       this.setState({ visible: false });
     }
   }
 
   accept = () => {
-    const { cookieName } = this.props;
+    const { localStorageName } = this.props;
 
-    Cookies.set(cookieName, true, { expires: new Date(2300, 1, 1) });
+    localStorage.setItem(localStorageName, "T");
     this.setState({ visible: false });
   };
 
@@ -84,4 +83,3 @@ class Environment extends React.Component {
 }
 
 export default Environment;
-export { Cookies };

--- a/src/components/banner/privacy.js
+++ b/src/components/banner/privacy.js
@@ -7,7 +7,6 @@
 
 // Core dependencies
 import { Link } from "gatsby";
-import Cookies from "js-cookie";
 import React from "react";
 
 // App dependencies
@@ -30,21 +29,21 @@ class Privacy extends React.Component {
   }
 
   componentDidMount() {
-    const { cookieName } = this.props;
+    const { localStorageName } = this.props;
 
-    if (Cookies.get(cookieName) === undefined) {
+    if (localStorage.getItem(localStorageName) === null) {
       this.setState({ visible: true });
     }
 
-    if (Cookies.get(cookieName) === true) {
+    if (localStorage.getItem(localStorageName) === "T") {
       this.setState({ visible: false });
     }
   }
 
   accept = () => {
-    const { cookieName } = this.props;
+    const { localStorageName } = this.props;
 
-    Cookies.set(cookieName, true, { expires: new Date(2300, 1, 1) });
+    localStorage.setItem(localStorageName, "T");
     this.setState({ visible: false });
   };
 
@@ -89,4 +88,3 @@ class Privacy extends React.Component {
 }
 
 export default Privacy;
-export { Cookies };


### PR DESCRIPTION
Switched the test and privacy banners to use local storage instead of cookies to determine whether they should show or not