### PR TITLE
feat: remove hca datasets network tab for networks that have an atlas (#2236)

### DIFF
--- a/next/@types/network.ts
+++ b/next/@types/network.ts
@@ -133,6 +133,7 @@ export interface Network {
   contact: Contact;
   coordinators: Coordinator[];
   datasetQueryOrgans: DatasetQueryOrgan[];
+  datasetURL?: string;
   key: NetworkKey;
   name: string;
   path: string;

--- a/next/components/BioNetworks/Network/Atlas/components/Datasets/components/MainColumn/mainColumn.tsx
+++ b/next/components/BioNetworks/Network/Atlas/components/Datasets/components/MainColumn/mainColumn.tsx
@@ -12,13 +12,16 @@ export const MainColumn = (): JSX.Element => {
   const {
     config: { browserURL },
   } = useConfig();
-  const { projectsResponses } = useAtlas();
+  const { network, projectsResponses } = useAtlas();
   return (
     <BackPageContentSingleColumn>
       {/* Atlas Datasets Description */}
       <FluidPaper>
         <MDXSection>
-          <AtlasDatasetsDescription />
+          <AtlasDatasetsDescription
+            networkName={network.name.toLowerCase()}
+            datasetURL={network.datasetURL}
+          />
         </MDXSection>
       </FluidPaper>
       {/* Atlas Datasets */}

--- a/next/components/BioNetworks/Network/components/common/Tabs/tabs.tsx
+++ b/next/components/BioNetworks/Network/components/common/Tabs/tabs.tsx
@@ -43,16 +43,18 @@ export const Tabs = (): JSX.Element => {
  * @returns network tabs.
  */
 function buildTabs(network: Network): Tab[] {
-  const { BICCNPublications, name } = network;
+  const { atlases, BICCNPublications, name } = network;
   const tabs = [];
   tabs.push({
     label: "Network Overview",
     value: NETWORKS_PATTERN,
   });
-  tabs.push({
-    label: `HCA ${getBioNetworkName(name)} Datasets`,
-    value: NETWORK_DATASETS_PATTERN,
-  });
+  if (atlases.length === 0) {
+    tabs.push({
+      label: `HCA ${getBioNetworkName(name)} Datasets`,
+      value: NETWORK_DATASETS_PATTERN,
+    });
+  }
   if (BICCNPublications && BICCNPublications.length > 0) {
     tabs.push({
       icon: (

--- a/next/content/BioNetworks/Network/Atlas/Datasets/description.mdx
+++ b/next/content/BioNetworks/Network/Atlas/Datasets/description.mdx
@@ -1,1 +1,3 @@
 The datasets below are ingested in the HCA Data Portal and used in the creation of the related integrated atlas. Additional datasets may have been used in the creation of the atlas. See the atlas publication for the full list of source datasets for the atlas.
+
+Additional {props.networkName} datasets can be found in the <Link label="HCA Data Explorer" url={props.datasetURL} />.

--- a/next/mdx-components.tsx
+++ b/next/mdx-components.tsx
@@ -1,0 +1,6 @@
+import { Link } from "@clevercanary/data-explorer-ui/lib/components/Links/components/Link/link";
+import { MDXComponents } from "mdx/types";
+
+export function useMDXComponents(components: MDXComponents): MDXComponents {
+  return { ...components, Link: Link };
+}

--- a/next/utils/network.ts
+++ b/next/utils/network.ts
@@ -11,6 +11,7 @@ import {
   processEntityValue,
   processNullElements,
 } from "../apis/azul/hca-dcp/common/utils";
+import { config } from "../config/config";
 
 /**
  * Returns the H5AD and RDS dataset assets for the given CellXGene dataset assets.
@@ -31,6 +32,21 @@ function buildDatasetAssets(
         fileType: cxgDatasetAsset.filetype,
       };
     });
+}
+
+/**
+ * Builds the URL for the dataset with filter values for the specimen organ category.
+ * @param network - Network.
+ * @returns dataset URL.
+ */
+export function buildDatasetURL(network: Network): string {
+  const { browserURL } = config();
+  const datasetURL = new URL(`${browserURL}/projects`);
+  const filters = [
+    { categoryKey: "specimenOrgan", value: network.datasetQueryOrgans },
+  ];
+  datasetURL.searchParams.set("filter", JSON.stringify(filters));
+  return datasetURL.href;
 }
 
 /**
@@ -95,7 +111,8 @@ export function processNetwork(
       .map(mapIntegratedAtlas);
     return { ...atlas, integratedAtlases };
   });
-  return { ...network, atlases };
+  const datasetURL = buildDatasetURL(network);
+  return { ...network, atlases, datasetURL };
 }
 
 /**


### PR DESCRIPTION
Closes #2236.