### PR TITLE
content: add endodern organoid atlas publication link (#2758)

### DIFF
--- a/constants/datasets.ts
+++ b/constants/datasets.ts
@@ -587,11 +587,11 @@ export const DATASETS = {
       [TODO],
       "An integrated transcriptomic cell atlas of human endoderm-derived organoids",
       {
-        doi: "10.1101/2023.11.20.567825",
+        doi: "10.1038/s41588-025-02182-6",
         officialHcaPublication: null,
         publicationTitle:
           "An integrated transcriptomic cell atlas of human endoderm-derived organoids",
-        publicationUrl: "https://doi.org/10.1101/2023.11.20.567825",
+        publicationUrl: "https://doi.org/10.1038/s41588-025-02182-6",
       }
     ),
     buildDataset(

--- a/constants/networks.ts
+++ b/constants/networks.ts
@@ -569,8 +569,9 @@ export const NETWORKS: Network[] = [
         path: ORGANOID_ENDODERM_V1_0,
         publications: [
           {
-            doi: "https://doi.org/10.1101/2023.11.20.567825",
-            label: "Xu et al. (2023) bioRxiv",
+            doi: "https://doi.org/10.1038/s41588-025-02182-6",
+            label:
+              "Xu, Q., Halle, L., Hediyeh-zadeh, S. et al. (2025) Nat Genet",
           },
         ],
         subTitle: "",


### PR DESCRIPTION
Closes #2758.

This pull request updates references to a publication in both the `datasets` and `networks` constants to reflect its transition from a preprint to a peer-reviewed journal article. The changes ensure consistency and accuracy in the metadata.

### Updates to publication metadata:

* [`constants/datasets.ts`](diffhunk://#diff-d03795dc707d80eb74f5a993e4844a8326258ecfaddf477938c2f4dd5997b08eL590-R594): Updated the DOI and publication URL for the "An integrated transcriptomic cell atlas of human endoderm-derived organoids" dataset to reflect the article's publication in *Nature Genetics*.
* [`constants/networks.ts`](diffhunk://#diff-c283311b9732dc1c175a63c508c1cde00a8bb30b9020c268cc9869f051522f37L572-R574): Updated the DOI and label for the same publication in the `NETWORKS` constant to match its new peer-reviewed status, including updated author details and publication year.

<img width="1597" alt="image" src="https://github.com/user-attachments/assets/d6321f3b-d451-4560-8393-038961c33b6e" />
