### PR TITLE
feat: filter tier 1 metadata by anndatalocation (#2781)

### DIFF
--- a/site-config/data-portal/dev/config.ts
+++ b/site-config/data-portal/dev/config.ts
@@ -16,11 +16,14 @@ import tier2SchemaHcaDataRepository from "./dataDictionary/tier-2-schema-hca-dat
 import { COLUMN_DEFS } from "../../../viewModelBuilders/dataDictionaryMapper/columnDefs";
 import { buildDataDictionary } from "../../../viewModelBuilders/dataDictionaryMapper/dataDictionaryMapper";
 import { DataDictionaryConfig } from "@databiosphere/findable-ui/lib/common/entities";
-import { TABLE_OPTIONS } from "../../../viewModelBuilders/dataDictionaryMapper/tableOptions";
+import {
+  TABLE_OPTIONS,
+  TIER_2_SCHEMA_TABLE_OPTIONS,
+} from "../../../viewModelBuilders/dataDictionaryMapper/tableOptions";
 import { SELECTED_MATCH } from "@databiosphere/findable-ui/lib/components/Layout/components/Header/common/entities";
 
 const APP_TITLE = "HCA Data Portal";
-const CATALOG = "dcp49";
+const CATALOG = "dcp50";
 export const DATA_URL = "https://service.azul.data.humancellatlas.org";
 const EXPLORER_URL = "https://explore.data.humancellatlas.dev.clevercanary.com";
 export const GIT_HUB_REPO_URL = "https://github.com/DataBiosphere/data-portal";
@@ -59,7 +62,7 @@ export function makeConfig(
       {
         dataDictionary: buildDataDictionary(tier2SchemaHcaDataRepository),
         path: "tier-2-schema-hca-data-repository",
-        tableOptions: TABLE_OPTIONS,
+        tableOptions: TIER_2_SCHEMA_TABLE_OPTIONS,
       },
       {
         dataDictionary: buildDataDictionary(cellAnnotationSchemaAnnData),

--- a/viewModelBuilders/dataDictionaryMapper/columnDefs.ts
+++ b/viewModelBuilders/dataDictionaryMapper/columnDefs.ts
@@ -3,101 +3,140 @@ import { Attribute } from "./types";
 import { FieldCell } from "../../components/DataDictionary/components/TableCell/components/FieldCell/fieldCell";
 import { DetailCell } from "../../components/DataDictionary/components/TableCell/components/DetailCell/detailCell";
 
+const ANN_DATA_LOCATION: ColumnDef<Attribute, unknown> = {
+  accessorFn: (row) => row.annotations?.annDataLocation,
+  enableColumnFilter: true,
+  enableGlobalFilter: false,
+  header: "AnnData Location",
+  id: "annDataLocation",
+};
+
+const BIO_NETWORK: ColumnDef<Attribute, unknown> = {
+  accessorFn: (row) => row.annotations?.bioNetworks,
+  enableColumnFilter: true,
+  enableGlobalFilter: false,
+  enableHiding: false,
+  filterFn: "arrIncludesSome",
+  header: "BioNetwork",
+  id: "bioNetwork",
+};
+
+const CLASS_KEY: ColumnDef<Attribute, unknown> = {
+  accessorKey: "classKey",
+  header: "Class Key",
+  enableColumnFilter: false,
+  enableGlobalFilter: false,
+  enableGrouping: true,
+  id: "classKey",
+};
+
+const DESCRIPTION: ColumnDef<Attribute, unknown> = {
+  accessorKey: "description",
+  enableColumnFilter: false,
+  enableGlobalFilter: true,
+  header: "Description",
+  id: "description",
+};
+
+const DETAILS: ColumnDef<Attribute, unknown> = {
+  accessorKey: "details",
+  cell: DetailCell,
+  enableColumnFilter: false,
+  enableGlobalFilter: false,
+  header: "Details",
+  id: "details",
+  meta: { width: "1fr" },
+};
+
+const FIELD: ColumnDef<Attribute, unknown> = {
+  accessorKey: "field",
+  cell: FieldCell,
+  enableColumnFilter: false,
+  enableGlobalFilter: false,
+  header: "Field",
+  id: "field",
+  meta: { width: { max: "264px", min: "264px" } },
+};
+
+const NAME: ColumnDef<Attribute, unknown> = {
+  accessorKey: "name",
+  enableColumnFilter: false,
+  enableGlobalFilter: true,
+  header: "Name",
+  id: "name",
+};
+
+const RATIONALE: ColumnDef<Attribute, unknown> = {
+  accessorKey: "rationale",
+  enableColumnFilter: false,
+  enableGlobalFilter: true,
+  header: "Rationale",
+  id: "rationale",
+};
+
+const REQUIRED: ColumnDef<Attribute, unknown> = {
+  accessorFn: (row) => (row.required ? "Required" : "Not Required"),
+  enableColumnFilter: true,
+  enableGlobalFilter: false,
+  enableHiding: false,
+  filterFn: "arrIncludesSome",
+  header: "Required",
+  id: "required",
+};
+
+const TIER: ColumnDef<Attribute, unknown> = {
+  accessorFn: (row) => row.annotations?.tier,
+  enableColumnFilter: false,
+  enableGlobalFilter: false,
+  enableHiding: false,
+  filterFn: "arrIncludesSome",
+  header: "Tier",
+  id: "tier",
+};
+
+const TITLE: ColumnDef<Attribute, unknown> = {
+  accessorKey: "title",
+  enableColumnFilter: false,
+  enableGlobalFilter: true,
+  header: "Title",
+  id: "title",
+};
+
+const VALUES: ColumnDef<Attribute, unknown> = {
+  accessorKey: "values",
+  header: "Allowed Values",
+  enableColumnFilter: false,
+  enableGlobalFilter: true,
+  id: "values",
+};
+
 export const COLUMN_DEFS: ColumnDef<Attribute, unknown>[] = [
-  {
-    accessorKey: "classKey",
-    header: "Class Key",
-    enableColumnFilter: false,
-    enableGlobalFilter: false,
-    enableGrouping: true,
-    id: "classKey",
-  },
-  {
-    accessorKey: "field",
-    cell: FieldCell,
-    enableColumnFilter: false,
-    enableGlobalFilter: false,
-    header: "Field",
-    id: "field",
-    meta: { width: { max: "264px", min: "264px" } },
-  },
-  {
-    accessorKey: "details",
-    cell: DetailCell,
-    enableColumnFilter: false,
-    enableGlobalFilter: false,
-    header: "Details",
-    id: "details",
-    meta: { width: "1fr" },
-  },
-  {
-    accessorFn: (row) => (row.required ? "Required" : "Not Required"),
-    enableColumnFilter: true,
-    enableGlobalFilter: false,
-    enableHiding: false,
-    filterFn: "arrIncludesSome",
-    header: "Required",
-    id: "required",
-  },
-  {
-    accessorFn: (row) => row.annotations?.bioNetworks,
-    enableColumnFilter: true,
-    enableGlobalFilter: false,
-    enableHiding: false,
-    filterFn: "arrIncludesSome",
-    header: "BioNetwork",
-    id: "bioNetwork",
-  },
-  {
-    accessorFn: (row) => row.annotations?.tier,
-    enableColumnFilter: false,
-    enableGlobalFilter: false,
-    enableHiding: false,
-    filterFn: "arrIncludesSome",
-    header: "Tier",
-    id: "tier",
-  },
+  CLASS_KEY,
+  FIELD,
+  DETAILS,
+  REQUIRED,
+  BIO_NETWORK,
+  TIER,
   /* GLOBAL FILTERS */
-  {
-    accessorFn: (row) => row.annotations?.annDataLocation,
-    enableColumnFilter: false,
-    enableGlobalFilter: true,
-    header: "AnnData Location",
-    id: "annDataLocation",
-  },
-  {
-    accessorKey: "name",
-    enableColumnFilter: false,
-    enableGlobalFilter: true,
-    header: "Name",
-    id: "name",
-  },
-  {
-    accessorKey: "description",
-    enableColumnFilter: false,
-    enableGlobalFilter: true,
-    header: "Description",
-    id: "description",
-  },
-  {
-    accessorKey: "title",
-    enableColumnFilter: false,
-    enableGlobalFilter: true,
-    header: "Title",
-    id: "title",
-  },
-  {
-    accessorKey: "rationale",
-    enableColumnFilter: false,
-    enableGlobalFilter: true,
-    header: "Rationale",
-    id: "rationale",
-  },
-  {
-    accessorKey: "values",
-    header: "Allowed Values",
-    enableColumnFilter: false,
-    enableGlobalFilter: true,
-    id: "values",
-  },
+  ANN_DATA_LOCATION,
+  NAME,
+  DESCRIPTION,
+  TITLE,
+  RATIONALE,
+  VALUES,
+];
+
+export const TIER_1_SCHEMA_COLUMN_DEFS: ColumnDef<Attribute, unknown>[] = [
+  CLASS_KEY,
+  FIELD,
+  DETAILS,
+  REQUIRED,
+  BIO_NETWORK,
+  TIER,
+  /* GLOBAL FILTERS */
+  NAME,
+  DESCRIPTION,
+  TITLE,
+  RATIONALE,
+  VALUES,
 ];

--- a/viewModelBuilders/dataDictionaryMapper/tableOptions.ts
+++ b/viewModelBuilders/dataDictionaryMapper/tableOptions.ts
@@ -1,6 +1,6 @@
 import { TableOptions } from "@tanstack/react-table";
 import { Attribute } from "./types";
-import { COLUMN_DEFS } from "./columnDefs";
+import { COLUMN_DEFS, TIER_1_SCHEMA_COLUMN_DEFS } from "./columnDefs";
 
 export const TABLE_OPTIONS: Omit<
   TableOptions<Attribute>,
@@ -10,6 +10,28 @@ export const TABLE_OPTIONS: Omit<
   initialState: {
     columnVisibility: {
       annDataLocation: false,
+      bioNetwork: false,
+      classKey: true,
+      description: false,
+      name: false,
+      rationale: false,
+      required: false,
+      tier: false,
+      title: false,
+      values: false,
+    },
+    expanded: true,
+    grouping: ["classKey"],
+  },
+};
+
+export const TIER_2_SCHEMA_TABLE_OPTIONS: Omit<
+  TableOptions<Attribute>,
+  "data" | "getCoreRowModel"
+> = {
+  columns: TIER_1_SCHEMA_COLUMN_DEFS,
+  initialState: {
+    columnVisibility: {
       bioNetwork: false,
       classKey: true,
       description: false,


### PR DESCRIPTION
Closes #2781.

This pull request introduces updates to the data dictionary configuration and column definitions to support tiered schema options, as well as enhancements to table options for better customization. The most important changes include adding new column definitions, introducing tier-specific table options, and updating the catalog version in the configuration.

### Updates to column definitions:

* [`viewModelBuilders/dataDictionaryMapper/columnDefs.ts`](diffhunk://#diff-10495c94e0d5f47859e7500c12d18908a1478c7fdf0883b03b5535ac0b3a4c1aL6-R141): Refactored `COLUMN_DEFS` to define individual column configurations as constants, enabling modularity and reuse. Added `TIER_1_SCHEMA_COLUMN_DEFS` for tier-specific schema support.

### Enhancements to table options:

* [`viewModelBuilders/dataDictionaryMapper/tableOptions.ts`](diffhunk://#diff-0b80c4f1540c198908ac22c618a8c0b10348e81871855fb37757cf303c14530bL3-R3): Introduced `TIER_2_SCHEMA_TABLE_OPTIONS` with customized column visibility and grouping for tier-2 schema support. Updated imports to include `TIER_1_SCHEMA_COLUMN_DEFS`. [[1]](diffhunk://#diff-0b80c4f1540c198908ac22c618a8c0b10348e81871855fb37757cf303c14530bL3-R3) [[2]](diffhunk://#diff-0b80c4f1540c198908ac22c618a8c0b10348e81871855fb37757cf303c14530bR27-R48)

### Configuration updates:

* [`site-config/data-portal/dev/config.ts`](diffhunk://#diff-09ef054390a74b1d1efb29c244e8c637cf7a751ab4422b29358ef132d63e3c66L19-R26): Updated the catalog version from `dcp49` to `dcp50`. Modified `tableOptions` in `makeConfig` to use `TIER_2_SCHEMA_TABLE_OPTIONS` for tier-2 schema data repository. [[1]](diffhunk://#diff-09ef054390a74b1d1efb29c244e8c637cf7a751ab4422b29358ef132d63e3c66L19-R26) [[2]](diffhunk://#diff-09ef054390a74b1d1efb29c244e8c637cf7a751ab4422b29358ef132d63e3c66L62-R65)

<img width="1428" height="1083" alt="image" src="https://github.com/user-attachments/assets/45f5f56e-30cc-45c1-8d43-037e770e3065" />

<img width="1434" height="955" alt="image" src="https://github.com/user-attachments/assets/cdbc051d-02bb-4250-862f-9bfa9188a93e" />

<img width="1430" height="1062" alt="image" src="https://github.com/user-attachments/assets/5fa41b54-544a-496f-826c-71532c1e5f5d" />

