### PR TITLE
fix: fix data dictionary text overflow on smaller viewports (#2785)

### DIFF
--- a/components/DataDictionary/components/TableCell/components/DetailCell/detailCell.styles.ts
+++ b/components/DataDictionary/components/TableCell/components/DetailCell/detailCell.styles.ts
@@ -2,6 +2,7 @@ import styled from "@emotion/styled";
 import { Button, Paper, Stack, Collapse } from "@mui/material";
 import { PALETTE } from "@databiosphere/findable-ui/lib/styles/common/constants/palette";
 import { textBody400 } from "@databiosphere/findable-ui/lib/styles/common/mixins/fonts";
+import { MarkdownCell } from "@databiosphere/findable-ui/lib/components/Table/components/TableCell/components/MarkdownCell/markdownCell";
 
 export const StyledCell = styled("div")`
   align-self: flex-start;
@@ -12,6 +13,10 @@ export const StyledCell = styled("div")`
     display: grid;
     gap: 4px;
   }
+`;
+
+export const StyledMarkdownCell = styled(MarkdownCell)`
+  min-width: 0;
 `;
 
 export const StyledCollapse = styled(Collapse)`

--- a/components/DataDictionary/components/TableCell/components/DetailCell/detailCell.tsx
+++ b/components/DataDictionary/components/TableCell/components/DetailCell/detailCell.tsx
@@ -13,9 +13,9 @@ import { Link } from "@databiosphere/findable-ui/lib/components/Links/components
 import { buildExample } from "./utils";
 import { useState } from "react";
 import { BUTTON_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/button";
-import { MarkdownCell } from "@databiosphere/findable-ui/lib/components/Table/components/TableCell/components/MarkdownCell/markdownCell";
 import { getPartialCellContext } from "../../utils";
 import { renderRankedCell } from "@databiosphere/findable-ui/lib/components/Table/components/TableCell/components/RankedCell/utils";
+import { StyledMarkdownCell } from "./detailCell.styles";
 
 export const DetailCell = ({
   row,
@@ -26,7 +26,7 @@ export const DetailCell = ({
     <StyledCell>
       <Grid>
         <Typography variant={TEXT_BODY_500}>Description</Typography>
-        <MarkdownCell
+        <StyledMarkdownCell
           {...getPartialCellContext({
             values: renderRankedCell(
               table,
@@ -41,7 +41,7 @@ export const DetailCell = ({
         {row.original.values && (
           <Grid>
             <Typography variant={TEXT_BODY_500}>Allowed Values</Typography>
-            <MarkdownCell
+            <StyledMarkdownCell
               {...getPartialCellContext({
                 values: renderRankedCell(
                   table,
@@ -68,7 +68,7 @@ export const DetailCell = ({
         {row.original.rationale && (
           <Grid>
             <Typography variant={TEXT_BODY_500}>Rationale</Typography>
-            <MarkdownCell
+            <StyledMarkdownCell
               {...getPartialCellContext({
                 values: renderRankedCell(
                   table,
@@ -87,7 +87,7 @@ export const DetailCell = ({
         {row.original.annotations?.tier && (
           <Grid>
             <Typography variant={TEXT_BODY_500}>Tier</Typography>
-            <MarkdownCell
+            <StyledMarkdownCell
               {...getPartialCellContext({
                 values: row.original.annotations.tier,
               })}
@@ -97,7 +97,7 @@ export const DetailCell = ({
         {row.original.annotations?.bioNetworks && (
           <Grid>
             <Typography variant={TEXT_BODY_500}>BioNetworks</Typography>
-            <MarkdownCell
+            <StyledMarkdownCell
               {...getPartialCellContext({
                 values: (row.original.annotations.bioNetworks as string[]).join(
                   ", "
@@ -108,7 +108,7 @@ export const DetailCell = ({
         )}
         <Grid>
           <Typography variant={TEXT_BODY_500}>AnnData Location</Typography>
-          <MarkdownCell
+          <StyledMarkdownCell
             {...getPartialCellContext({
               values: renderRankedCell(
                 table,


### PR DESCRIPTION
Closes #2785.

This pull request refactors the `DetailCell` component by replacing the use of the `MarkdownCell` component with a new styled wrapper, `StyledMarkdownCell`. This change ensures consistent styling and improves maintainability by centralizing style customizations.

### Component Refactoring:

* Introduced a new styled component `StyledMarkdownCell` in `detailCell.styles.ts` to wrap the `MarkdownCell` component with additional styling properties such as `min-width: 0`. [[1]](diffhunk://#diff-5cdaab3acfdae7fa1deae1117971e22461f1d47f174bc55eac02da03b099ad71R5) [[2]](diffhunk://#diff-5cdaab3acfdae7fa1deae1117971e22461f1d47f174bc55eac02da03b099ad71R18-R21)
* Updated `DetailCell` in `detailCell.tsx` to use `StyledMarkdownCell` instead of `MarkdownCell` across all instances where Markdown content is rendered. This includes sections for "Description," "Allowed Values," "Rationale," "Tier," "BioNetworks," and "AnnData Location." [[1]](diffhunk://#diff-069661689f0ee6c12fb3f5fcf9db40cb7bca4c2dfc90225fd01436a3861db732L29-R29) [[2]](diffhunk://#diff-069661689f0ee6c12fb3f5fcf9db40cb7bca4c2dfc90225fd01436a3861db732L44-R44) [[3]](diffhunk://#diff-069661689f0ee6c12fb3f5fcf9db40cb7bca4c2dfc90225fd01436a3861db732L71-R71) [[4]](diffhunk://#diff-069661689f0ee6c12fb3f5fcf9db40cb7bca4c2dfc90225fd01436a3861db732L90-R90) [[5]](diffhunk://#diff-069661689f0ee6c12fb3f5fcf9db40cb7bca4c2dfc90225fd01436a3861db732L100-R100) [[6]](diffhunk://#diff-069661689f0ee6c12fb3f5fcf9db40cb7bca4c2dfc90225fd01436a3861db732L111-R111)

<img width="505" height="1064" alt="image" src="https://github.com/user-attachments/assets/98a7159d-668c-473d-8b7e-1481a1bcfdc6" />
