### PR TITLE
feat: update data dictionary accordion interaction (#2786)

### DIFF
--- a/components/DataDictionary/components/TableCell/components/DetailCell/constants.ts
+++ b/components/DataDictionary/components/TableCell/components/DetailCell/constants.ts
@@ -1,0 +1,8 @@
+import { TYPOGRAPHY_PROPS as MUI_TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
+import { TypographyProps } from "@mui/material";
+
+export const TYPOGRAPHY_PROPS: TypographyProps = {
+  component: "div",
+  gutterBottom: true,
+  variant: MUI_TYPOGRAPHY_PROPS.VARIANT.TEXT_BODY_500,
+};

--- a/components/DataDictionary/components/TableCell/components/DetailCell/detailCell.styles.ts
+++ b/components/DataDictionary/components/TableCell/components/DetailCell/detailCell.styles.ts
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { Button, Paper, Stack, Collapse } from "@mui/material";
+import { Paper, Stack, Collapse } from "@mui/material";
 import { PALETTE } from "@databiosphere/findable-ui/lib/styles/common/constants/palette";
 import { textBody400 } from "@databiosphere/findable-ui/lib/styles/common/mixins/fonts";
 import { MarkdownCell } from "@databiosphere/findable-ui/lib/components/Table/components/TableCell/components/MarkdownCell/markdownCell";
@@ -9,9 +9,8 @@ export const StyledCell = styled("div")`
   justify-items: flex-start;
   padding: 8px 0;
 
-  .MuiGrid-root {
-    display: grid;
-    gap: 4px;
+  .MuiTypography-gutterBottom {
+    margin-bottom: 4px;
   }
 `;
 
@@ -38,14 +37,4 @@ export const StyledPaper = styled(Paper)`
   box-shadow: 0 0 0 1px ${PALETTE.SMOKE_MAIN};
   font-family: "Roboto Mono", monospace;
   padding: 8px 12px;
-`;
-
-export const StyledButton = styled(Button)`
-  ${textBody400};
-  padding-top: 16px;
-
-  &:hover {
-    background-color: transparent;
-    text-decoration: underline;
-  }
 `;

--- a/components/DataDictionary/components/TableCell/components/DetailCell/detailCell.tsx
+++ b/components/DataDictionary/components/TableCell/components/DetailCell/detailCell.tsx
@@ -1,18 +1,15 @@
 import { CellContext } from "@tanstack/react-table";
 import { Attribute } from "../../../../../../viewModelBuilders/dataDictionaryMapper/types";
-import { Grid, Typography } from "@mui/material";
-import { TEXT_BODY_500 } from "@databiosphere/findable-ui/lib/theme/common/typography";
+import { Collapse, Typography } from "@mui/material";
+import { TYPOGRAPHY_PROPS } from "./constants";
 import {
   StyledPaper,
   StyledCell,
   StyledStack,
   StyledCollapse,
-  StyledButton,
 } from "./detailCell.styles";
-import { Link } from "@databiosphere/findable-ui/lib/components/Links/components/Link/link";
+import { LinkCell } from "@databiosphere/findable-ui/lib/components/Table/components/TableCell/components/LinkCell/linkCell";
 import { buildExample } from "./utils";
-import { useState } from "react";
-import { BUTTON_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/button";
 import { getPartialCellContext } from "../../utils";
 import { renderRankedCell } from "@databiosphere/findable-ui/lib/components/Table/components/TableCell/components/RankedCell/utils";
 import { StyledMarkdownCell } from "./detailCell.styles";
@@ -21,26 +18,27 @@ export const DetailCell = ({
   row,
   table,
 }: CellContext<Attribute, unknown>): JSX.Element => {
-  const [isIn, setIsIn] = useState(false);
+  const { getIsExpanded } = row;
+  const isExpanded = getIsExpanded();
   return (
     <StyledCell>
-      <Grid>
-        <Typography variant={TEXT_BODY_500}>Description</Typography>
-        <StyledMarkdownCell
-          {...getPartialCellContext({
-            values: renderRankedCell(
-              table,
-              row,
-              "description",
-              row.original.description
-            ),
-          })}
-        />
-      </Grid>
-      <StyledCollapse in={isIn}>
+      <Collapse in={isExpanded}>
+        <Typography {...TYPOGRAPHY_PROPS}>Description</Typography>
+      </Collapse>
+      <StyledMarkdownCell
+        {...getPartialCellContext({
+          values: renderRankedCell(
+            table,
+            row,
+            "description",
+            row.original.description
+          ),
+        })}
+      />
+      <StyledCollapse in={isExpanded}>
         {row.original.values && (
-          <Grid>
-            <Typography variant={TEXT_BODY_500}>Allowed Values</Typography>
+          <div>
+            <Typography {...TYPOGRAPHY_PROPS}>Allowed Values</Typography>
             <StyledMarkdownCell
               {...getPartialCellContext({
                 values: renderRankedCell(
@@ -51,11 +49,11 @@ export const DetailCell = ({
                 ),
               })}
             />
-          </Grid>
+          </div>
         )}
         {row.original.example && (
-          <Grid>
-            <Typography variant={TEXT_BODY_500}>Example</Typography>
+          <div>
+            <Typography {...TYPOGRAPHY_PROPS}>Example</Typography>
             <StyledStack direction="row">
               {buildExample(row.original).map((example, i) => (
                 <StyledPaper key={i} elevation={0}>
@@ -63,11 +61,11 @@ export const DetailCell = ({
                 </StyledPaper>
               ))}
             </StyledStack>
-          </Grid>
+          </div>
         )}
         {row.original.rationale && (
-          <Grid>
-            <Typography variant={TEXT_BODY_500}>Rationale</Typography>
+          <div>
+            <Typography {...TYPOGRAPHY_PROPS}>Rationale</Typography>
             <StyledMarkdownCell
               {...getPartialCellContext({
                 values: renderRankedCell(
@@ -78,25 +76,25 @@ export const DetailCell = ({
                 ),
               })}
             />
-          </Grid>
+          </div>
         )}
-        <Grid>
-          <Typography variant={TEXT_BODY_500}>Source</Typography>
-          <Link {...row.original.source} />
-        </Grid>
+        <div>
+          <Typography {...TYPOGRAPHY_PROPS}>Source</Typography>
+          <LinkCell {...getPartialCellContext(row.original.source)} />
+        </div>
         {row.original.annotations?.tier && (
-          <Grid>
-            <Typography variant={TEXT_BODY_500}>Tier</Typography>
+          <div>
+            <Typography {...TYPOGRAPHY_PROPS}>Tier</Typography>
             <StyledMarkdownCell
               {...getPartialCellContext({
                 values: row.original.annotations.tier,
               })}
             />
-          </Grid>
+          </div>
         )}
         {row.original.annotations?.bioNetworks && (
-          <Grid>
-            <Typography variant={TEXT_BODY_500}>BioNetworks</Typography>
+          <div>
+            <Typography {...TYPOGRAPHY_PROPS}>BioNetworks</Typography>
             <StyledMarkdownCell
               {...getPartialCellContext({
                 values: (row.original.annotations.bioNetworks as string[]).join(
@@ -104,10 +102,10 @@ export const DetailCell = ({
                 ),
               })}
             />
-          </Grid>
+          </div>
         )}
-        <Grid>
-          <Typography variant={TEXT_BODY_500}>AnnData Location</Typography>
+        <div>
+          <Typography {...TYPOGRAPHY_PROPS}>AnnData Location</Typography>
           <StyledMarkdownCell
             {...getPartialCellContext({
               values: renderRankedCell(
@@ -118,14 +116,8 @@ export const DetailCell = ({
               ),
             })}
           />
-        </Grid>
+        </div>
       </StyledCollapse>
-      <StyledButton
-        onClick={() => setIsIn((i) => !i)}
-        variant={BUTTON_PROPS.VARIANT.TEXT}
-      >
-        {isIn ? "Show less" : "Show more"}
-      </StyledButton>
     </StyledCell>
   );
 };

--- a/components/DataDictionary/components/TableCell/components/FieldCell/fieldCell.tsx
+++ b/components/DataDictionary/components/TableCell/components/FieldCell/fieldCell.tsx
@@ -1,13 +1,13 @@
 import { CellContext } from "@tanstack/react-table";
 import { Attribute } from "../../../../../../viewModelBuilders/dataDictionaryMapper/types";
 import { Chip, Typography } from "@mui/material";
-import { TEXT_BODY_500 } from "@databiosphere/findable-ui/lib/theme/common/typography";
 import { StyledGrid } from "./fieldCell.styles";
 import { buildRequired, buildRange } from "./utils";
 import { CodeCell } from "@databiosphere/findable-ui/lib/components/Table/components/TableCell/components/CodeCell/codeCell";
 import { getPartialCellContext } from "../../utils";
 import { renderRankedCell } from "@databiosphere/findable-ui/lib/components/Table/components/TableCell/components/RankedCell/utils";
 import { MarkdownCell } from "@databiosphere/findable-ui/lib/components/Table/components/TableCell/components/MarkdownCell/markdownCell";
+import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
 
 export const FieldCell = ({
   row,
@@ -16,7 +16,10 @@ export const FieldCell = ({
   return (
     <StyledGrid>
       {/* TITLE */}
-      <Typography component="div" variant={TEXT_BODY_500}>
+      <Typography
+        component="div"
+        variant={TYPOGRAPHY_PROPS.VARIANT.TEXT_BODY_500}
+      >
         <MarkdownCell
           {...getPartialCellContext({
             values: renderRankedCell(table, row, "title", row.original.title),

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "next",
       "version": "2.5.0",
       "dependencies": {
-        "@databiosphere/findable-ui": "^38.2.0",
+        "@databiosphere/findable-ui": "^38.3.0",
         "@emotion/react": "^11.13.3",
         "@emotion/styled": "^11.13.0",
         "@mdx-js/loader": "^3.0.1",
@@ -560,9 +560,9 @@
       }
     },
     "node_modules/@databiosphere/findable-ui": {
-      "version": "38.2.0",
-      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-38.2.0.tgz",
-      "integrity": "sha512-NNnPRw0KGY2LhtTiV/8d83ENl/Iz7DmDqo+5iXPb2CnlHCEyJ7VIvon5fij0HZ655tpIbU5Ou8x61BPwlw9YYw==",
+      "version": "38.3.0",
+      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-38.3.0.tgz",
+      "integrity": "sha512-73jezbM8Io2jE5hPmbHdhdbp7btbQ3nGkVXr4TdGTaE7iSPTVN2wFSmu1Yun7asIU00dTyTvqa379KJGCTDBKA==",
       "engines": {
         "node": "20.10.0"
       },
@@ -853,9 +853,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -932,9 +932,9 @@
       }
     },
     "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -1455,9 +1455,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "14.2.28",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.28.tgz",
-      "integrity": "sha512-PAmWhJfJQlP+kxZwCjrVd9QnR5x0R3u0mTXTiZDgSd4h5LdXmjxCCWbN9kq6hkZBOax8Rm3xDW5HagWyJuT37g=="
+      "version": "14.2.30",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.30.tgz",
+      "integrity": "sha512-KBiBKrDY6kxTQWGzKjQB7QirL3PiiOkV7KW98leHFjtVRKtft76Ra5qSA/SL75xT44dp6hOcqiiJ6iievLOYug=="
     },
     "node_modules/@next/eslint-plugin-next": {
       "version": "14.2.28",
@@ -1497,9 +1497,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "14.2.28",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.28.tgz",
-      "integrity": "sha512-kzGChl9setxYWpk3H6fTZXXPFFjg7urptLq5o5ZgYezCrqlemKttwMT5iFyx/p1e/JeglTwDFRtb923gTJ3R1w==",
+      "version": "14.2.30",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.30.tgz",
+      "integrity": "sha512-EAqfOTb3bTGh9+ewpO/jC59uACadRHM6TSA9DdxJB/6gxOpyV+zrbqeXiFTDy9uV6bmipFDkfpAskeaDcO+7/g==",
       "cpu": [
         "arm64"
       ],
@@ -1512,9 +1512,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "14.2.28",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.28.tgz",
-      "integrity": "sha512-z6FXYHDJlFOzVEOiiJ/4NG8aLCeayZdcRSMjPDysW297Up6r22xw6Ea9AOwQqbNsth8JNgIK8EkWz2IDwaLQcw==",
+      "version": "14.2.30",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.30.tgz",
+      "integrity": "sha512-TyO7Wz1IKE2kGv8dwQ0bmPL3s44EKVencOqwIY69myoS3rdpO1NPg5xPM5ymKu7nfX4oYJrpMxv8G9iqLsnL4A==",
       "cpu": [
         "x64"
       ],
@@ -1527,9 +1527,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "14.2.28",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.28.tgz",
-      "integrity": "sha512-9ARHLEQXhAilNJ7rgQX8xs9aH3yJSj888ssSjJLeldiZKR4D7N08MfMqljk77fAwZsWwsrp8ohHsMvurvv9liQ==",
+      "version": "14.2.30",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.30.tgz",
+      "integrity": "sha512-I5lg1fgPJ7I5dk6mr3qCH1hJYKJu1FsfKSiTKoYwcuUf53HWTrEkwmMI0t5ojFKeA6Vu+SfT2zVy5NS0QLXV4Q==",
       "cpu": [
         "arm64"
       ],
@@ -1542,9 +1542,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "14.2.28",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.28.tgz",
-      "integrity": "sha512-p6gvatI1nX41KCizEe6JkF0FS/cEEF0u23vKDpl+WhPe/fCTBeGkEBh7iW2cUM0rvquPVwPWdiUR6Ebr/kQWxQ==",
+      "version": "14.2.30",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.30.tgz",
+      "integrity": "sha512-8GkNA+sLclQyxgzCDs2/2GSwBc92QLMrmYAmoP2xehe5MUKBLB2cgo34Yu242L1siSkwQkiV4YLdCnjwc/Micw==",
       "cpu": [
         "arm64"
       ],
@@ -1557,9 +1557,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "14.2.28",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.28.tgz",
-      "integrity": "sha512-nsiSnz2wO6GwMAX2o0iucONlVL7dNgKUqt/mDTATGO2NY59EO/ZKnKEr80BJFhuA5UC1KZOMblJHWZoqIJddpA==",
+      "version": "14.2.30",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.30.tgz",
+      "integrity": "sha512-8Ly7okjssLuBoe8qaRCcjGtcMsv79hwzn/63wNeIkzJVFVX06h5S737XNr7DZwlsbTBDOyI6qbL2BJB5n6TV/w==",
       "cpu": [
         "x64"
       ],
@@ -1572,9 +1572,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "14.2.28",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.28.tgz",
-      "integrity": "sha512-+IuGQKoI3abrXFqx7GtlvNOpeExUH1mTIqCrh1LGFf8DnlUcTmOOCApEnPJUSLrSbzOdsF2ho2KhnQoO0I1RDw==",
+      "version": "14.2.30",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.30.tgz",
+      "integrity": "sha512-dBmV1lLNeX4mR7uI7KNVHsGQU+OgTG5RGFPi3tBJpsKPvOPtg9poyav/BYWrB3GPQL4dW5YGGgalwZ79WukbKQ==",
       "cpu": [
         "x64"
       ],
@@ -1587,9 +1587,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "14.2.28",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.28.tgz",
-      "integrity": "sha512-l61WZ3nevt4BAnGksUVFKy2uJP5DPz2E0Ma/Oklvo3sGj9sw3q7vBWONFRgz+ICiHpW5mV+mBrkB3XEubMrKaA==",
+      "version": "14.2.30",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.30.tgz",
+      "integrity": "sha512-6MMHi2Qc1Gkq+4YLXAgbYslE1f9zMGBikKMdmQRHXjkGPot1JY3n5/Qrbg40Uvbi8//wYnydPnyvNhI1DMUW1g==",
       "cpu": [
         "arm64"
       ],
@@ -1602,9 +1602,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "14.2.28",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.28.tgz",
-      "integrity": "sha512-+Kcp1T3jHZnJ9v9VTJ/yf1t/xmtFAc/Sge4v7mVc1z+NYfYzisi8kJ9AsY8itbgq+WgEwMtOpiLLJsUy2qnXZw==",
+      "version": "14.2.30",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.30.tgz",
+      "integrity": "sha512-pVZMnFok5qEX4RT59mK2hEVtJX+XFfak+/rjHpyFh7juiT52r177bfFKhnlafm0UOSldhXjj32b+LZIOdswGTg==",
       "cpu": [
         "ia32"
       ],
@@ -1617,9 +1617,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "14.2.28",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.28.tgz",
-      "integrity": "sha512-1gCmpvyhz7DkB1srRItJTnmR2UwQPAUXXIg9r0/56g3O8etGmwlX68skKXJOp9EejW3hhv7nSQUJ2raFiz4MoA==",
+      "version": "14.2.30",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.30.tgz",
+      "integrity": "sha512-4KCo8hMZXMjpTzs3HOqOGYYwAXymXIy7PEPAXNEcEOyKqkjiDlECumrWziy+JEF0Oi4ILHGxzgQ3YiMGG2t/Lg==",
       "cpu": [
         "x64"
       ],
@@ -2778,9 +2778,9 @@
       "integrity": "sha512-H0ea4Fd3lS1+sTEB2TgcLoK21lLhwEJzlQv3IN47pJS976Gx4zoWe0ak3q+uYh60ppQxg9F16Ri4tS1sfD4+jA=="
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -4520,9 +4520,9 @@
       }
     },
     "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -4654,9 +4654,9 @@
       }
     },
     "node_modules/eslint-plugin-jsx-a11y/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -4750,9 +4750,9 @@
       }
     },
     "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -4935,9 +4935,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -10983,11 +10983,11 @@
       "dev": true
     },
     "node_modules/next": {
-      "version": "14.2.28",
-      "resolved": "https://registry.npmjs.org/next/-/next-14.2.28.tgz",
-      "integrity": "sha512-QLEIP/kYXynIxtcKB6vNjtWLVs3Y4Sb+EClTC/CSVzdLD1gIuItccpu/n1lhmduffI32iPGEK2cLLxxt28qgYA==",
+      "version": "14.2.30",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.2.30.tgz",
+      "integrity": "sha512-+COdu6HQrHHFQ1S/8BBsCag61jZacmvbuL2avHvQFbWa2Ox7bE+d8FyNgxRLjXQ5wtPyQwEmk85js/AuaG2Sbg==",
       "dependencies": {
-        "@next/env": "14.2.28",
+        "@next/env": "14.2.30",
         "@swc/helpers": "0.5.5",
         "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001579",
@@ -11002,15 +11002,15 @@
         "node": ">=18.17.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "14.2.28",
-        "@next/swc-darwin-x64": "14.2.28",
-        "@next/swc-linux-arm64-gnu": "14.2.28",
-        "@next/swc-linux-arm64-musl": "14.2.28",
-        "@next/swc-linux-x64-gnu": "14.2.28",
-        "@next/swc-linux-x64-musl": "14.2.28",
-        "@next/swc-win32-arm64-msvc": "14.2.28",
-        "@next/swc-win32-ia32-msvc": "14.2.28",
-        "@next/swc-win32-x64-msvc": "14.2.28"
+        "@next/swc-darwin-arm64": "14.2.30",
+        "@next/swc-darwin-x64": "14.2.30",
+        "@next/swc-linux-arm64-gnu": "14.2.30",
+        "@next/swc-linux-arm64-musl": "14.2.30",
+        "@next/swc-linux-x64-gnu": "14.2.30",
+        "@next/swc-linux-x64-musl": "14.2.30",
+        "@next/swc-win32-arm64-msvc": "14.2.30",
+        "@next/swc-win32-ia32-msvc": "14.2.30",
+        "@next/swc-win32-x64-msvc": "14.2.30"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -13974,9 +13974,9 @@
       }
     },
     "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "get-cellxgene-projects": "esrun ./scripts/get-cellxgene-projects.ts"
   },
   "dependencies": {
-    "@databiosphere/findable-ui": "^38.2.0",
+    "@databiosphere/findable-ui": "^38.3.0",
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
     "@mdx-js/loader": "^3.0.1",

--- a/viewModelBuilders/dataDictionaryMapper/columnDefs.ts
+++ b/viewModelBuilders/dataDictionaryMapper/columnDefs.ts
@@ -43,7 +43,7 @@ const DETAILS: ColumnDef<Attribute, unknown> = {
   cell: DetailCell,
   enableColumnFilter: false,
   enableGlobalFilter: false,
-  header: "Details",
+  header: "Description",
   id: "details",
   meta: { width: "1fr" },
 };
@@ -85,7 +85,7 @@ const REQUIRED: ColumnDef<Attribute, unknown> = {
 };
 
 const SOURCE: ColumnDef<Attribute, unknown> = {
-  accessorFn: (row) => row.source?.label || "None",
+  accessorFn: (row) => row.source?.children || "None",
   enableColumnFilter: true,
   enableGlobalFilter: false,
   enableHiding: false,

--- a/viewModelBuilders/dataDictionaryMapper/tableOptions.ts
+++ b/viewModelBuilders/dataDictionaryMapper/tableOptions.ts
@@ -21,7 +21,6 @@ export const TABLE_OPTIONS: Omit<
       title: false,
       values: false,
     },
-    expanded: true,
     grouping: ["classKey"],
   },
 };
@@ -44,7 +43,6 @@ export const TIER_2_SCHEMA_TABLE_OPTIONS: Omit<
       title: false,
       values: false,
     },
-    expanded: true,
     grouping: ["classKey"],
   },
 };

--- a/viewModelBuilders/dataDictionaryMapper/types.ts
+++ b/viewModelBuilders/dataDictionaryMapper/types.ts
@@ -1,5 +1,5 @@
 import { Attribute as BaseAttribute } from "@databiosphere/findable-ui/lib/common/entities";
-import { LinkProps } from "@databiosphere/findable-ui/lib/components/Links/components/Link/link";
+import { LinkProps } from "@mui/material";
 
 export interface Attribute extends BaseAttribute {
   source: LinkProps;

--- a/viewModelBuilders/dataDictionaryMapper/viewModelBuilders.ts
+++ b/viewModelBuilders/dataDictionaryMapper/viewModelBuilders.ts
@@ -25,7 +25,7 @@ export function buildSourceAttribute(
     Object.keys(annotations).length === 0 ||
     Object.keys(prefixes).length === 0
   ) {
-    return { label: LABEL.NONE, url: "" };
+    return { children: LABEL.NONE, href: "" };
   }
 
   // Determine the key to use, either cxg or cap.
@@ -33,7 +33,7 @@ export function buildSourceAttribute(
     (key) => key === "cxg" || key === "cap"
   );
   if (!sourceKey) {
-    return { label: LABEL.NONE, url: "" };
+    return { children: LABEL.NONE, href: "" };
   }
 
   // Check for source
@@ -43,11 +43,11 @@ export function buildSourceAttribute(
     attributeAnnotations?.[sourceKey]
   ) {
     return {
-      label: annotations[sourceKey],
-      url: `${prefixes[sourceKey]}/#${attributeAnnotations[sourceKey]}`,
+      children: annotations[sourceKey],
+      href: `${prefixes[sourceKey]}/#${attributeAnnotations[sourceKey]}`,
     };
   }
 
   // Default if neither CXG nor CAP is found, or if attribute has no relevant annotations
-  return { label: LABEL.NONE, url: "" };
+  return { children: LABEL.NONE, href: "" };
 }


### PR DESCRIPTION
Closes #2786.

This pull request refactors the `DetailCell` and `FieldCell` components, improves the use of typography constants, updates the data dictionary table options, and modifies the structure of the `source` attribute. The changes aim to simplify the codebase, improve maintainability, and align with updated dependencies.

### Component Refactoring and Styling Updates:
* Refactored `DetailCell` to replace `Grid` with `div` elements, removed the toggle button, and replaced `useState` with the `getIsExpanded` method for managing expansion state. Updated typography usage to leverage the `TYPOGRAPHY_PROPS` constant. [[1]](diffhunk://#diff-069661689f0ee6c12fb3f5fcf9db40cb7bca4c2dfc90225fd01436a3861db732L3-L15) [[2]](diffhunk://#diff-069661689f0ee6c12fb3f5fcf9db40cb7bca4c2dfc90225fd01436a3861db732L24-R27) [[3]](diffhunk://#diff-069661689f0ee6c12fb3f5fcf9db40cb7bca4c2dfc90225fd01436a3861db732L39-R41) [[4]](diffhunk://#diff-069661689f0ee6c12fb3f5fcf9db40cb7bca4c2dfc90225fd01436a3861db732L54-R68) [[5]](diffhunk://#diff-069661689f0ee6c12fb3f5fcf9db40cb7bca4c2dfc90225fd01436a3861db732L81-R108) [[6]](diffhunk://#diff-069661689f0ee6c12fb3f5fcf9db40cb7bca4c2dfc90225fd01436a3861db732L121-L128)
* Updated `FieldCell` to use `TYPOGRAPHY_PROPS` for consistent typography styling. [[1]](diffhunk://#diff-cd3ea5c983342d18f6cdef697b3f41b5d0901fdc30cb8b33c8d62108aa05afa0L4-R10) [[2]](diffhunk://#diff-cd3ea5c983342d18f6cdef697b3f41b5d0901fdc30cb8b33c8d62108aa05afa0L19-R22)
* Removed unused `StyledButton` and associated styles from `detailCell.styles.ts`.

### Typography and Dependency Updates:
* Introduced a new `TYPOGRAPHY_PROPS` constant in `constants.ts` to centralize typography configuration.
* Upgraded `@databiosphere/findable-ui` dependency to version `^38.3.0` to align with the latest library updates.

### Data Dictionary Table Updates:
* Changed the `header` of the "Details" column to "Description" in `columnDefs.ts` for better clarity.
* Updated the `source` column accessor to use `children` instead of `label`.
* Removed the default `expanded` state from `TABLE_OPTIONS` and `TIER_2_SCHEMA_TABLE_OPTIONS` in `tableOptions.ts`. [[1]](diffhunk://#diff-0b80c4f1540c198908ac22c618a8c0b10348e81871855fb37757cf303c14530bL24) [[2]](diffhunk://#diff-0b80c4f1540c198908ac22c618a8c0b10348e81871855fb37757cf303c14530bL47)

### Attribute Type Updates:
* Modified the `source` attribute in `types.ts` to use `LinkProps` from `@mui/material` instead of `@databiosphere/findable-ui`.
* Updated `buildSourceAttribute` in `viewModelBuilders.ts` to use `children` and `href` instead of `label` and `url`. [[1]](diffhunk://#diff-5d75d4b753833e26400f5a50614c84d6381c8bde35426c58f8f59b883231dfdbL28-R36) [[2]](diffhunk://#diff-5d75d4b753833e26400f5a50614c84d6381c8bde35426c58f8f59b883231dfdbL46-R52)

<img width="1628" height="1159" alt="image" src="https://github.com/user-attachments/assets/737b2300-dd81-47bb-b702-1b3ad7b98872" />
