### PR TITLE
feat: update data dictionary responsive layout (#2787)

### DIFF
--- a/components/DataDictionary/components/TableCell/components/FieldCell/constants.ts
+++ b/components/DataDictionary/components/TableCell/components/FieldCell/constants.ts
@@ -1,0 +1,8 @@
+import { GridProps } from "@mui/material";
+
+export const GRID_PROPS: GridProps = {
+  container: true,
+  direction: "row",
+  spacing: 2,
+  wrap: "wrap",
+};

--- a/components/DataDictionary/components/TableCell/components/FieldCell/fieldCell.tsx
+++ b/components/DataDictionary/components/TableCell/components/FieldCell/fieldCell.tsx
@@ -1,6 +1,6 @@
 import { CellContext } from "@tanstack/react-table";
 import { Attribute } from "../../../../../../viewModelBuilders/dataDictionaryMapper/types";
-import { Chip, Typography } from "@mui/material";
+import { Chip, Grid, Typography } from "@mui/material";
 import { StyledGrid } from "./fieldCell.styles";
 import { buildRequired, buildRange } from "./utils";
 import { CodeCell } from "@databiosphere/findable-ui/lib/components/Table/components/TableCell/components/CodeCell/codeCell";
@@ -8,6 +8,7 @@ import { getPartialCellContext } from "../../utils";
 import { renderRankedCell } from "@databiosphere/findable-ui/lib/components/Table/components/TableCell/components/RankedCell/utils";
 import { MarkdownCell } from "@databiosphere/findable-ui/lib/components/Table/components/TableCell/components/MarkdownCell/markdownCell";
 import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
+import { GRID_PROPS } from "./constants";
 
 export const FieldCell = ({
   row,
@@ -26,18 +27,20 @@ export const FieldCell = ({
           })}
         />
       </Typography>
-      {/* NAME */}
-      <CodeCell
-        {...getPartialCellContext(
-          <MarkdownCell
-            {...getPartialCellContext({
-              values: renderRankedCell(table, row, "name", row.original.name),
-            })}
-          />
-        )}
-      />
-      {/* REQUIRED */}
-      {row.original.required && <Chip {...buildRequired(row.original)} />}
+      <Grid {...GRID_PROPS}>
+        {/* NAME */}
+        <CodeCell
+          {...getPartialCellContext(
+            <MarkdownCell
+              {...getPartialCellContext({
+                values: renderRankedCell(table, row, "name", row.original.name),
+              })}
+            />
+          )}
+        />
+        {/* REQUIRED */}
+        {row.original.required && <Chip {...buildRequired(row.original)} />}
+      </Grid>
       {/* RANGE */}
       <div>{buildRange(row.original)}</div>
     </StyledGrid>

--- a/viewModelBuilders/dataDictionaryMapper/columnDefs.ts
+++ b/viewModelBuilders/dataDictionaryMapper/columnDefs.ts
@@ -57,10 +57,8 @@ const FIELD: ColumnDef<Attribute, unknown> = {
   header: "Field",
   id: "field",
   meta: {
-    width: {
-      min: "min(32%, 352px)", // TODO: update GridTrackSize to handle css functions min(), max().
-      max: "min(31%, 496px)",
-    } as unknown as GridTrackSize,
+    width:
+      "round(up, clamp(min(31.26%, 352px), 31.26%, 496px), 1px)" as GridTrackSize,
   },
 };
 

--- a/viewModelBuilders/dataDictionaryMapper/columnDefs.ts
+++ b/viewModelBuilders/dataDictionaryMapper/columnDefs.ts
@@ -2,6 +2,7 @@ import { ColumnDef } from "@tanstack/react-table";
 import { Attribute } from "./types";
 import { FieldCell } from "../../components/DataDictionary/components/TableCell/components/FieldCell/fieldCell";
 import { DetailCell } from "../../components/DataDictionary/components/TableCell/components/DetailCell/detailCell";
+import { GridTrackSize } from "@databiosphere/findable-ui/lib/config/entities";
 
 const ANN_DATA_LOCATION: ColumnDef<Attribute, unknown> = {
   accessorFn: (row) => row.annotations?.annDataLocation,
@@ -45,7 +46,7 @@ const DETAILS: ColumnDef<Attribute, unknown> = {
   enableGlobalFilter: false,
   header: "Description",
   id: "details",
-  meta: { width: "1fr" },
+  meta: { width: { min: "396px", max: "1fr" } },
 };
 
 const FIELD: ColumnDef<Attribute, unknown> = {
@@ -55,7 +56,12 @@ const FIELD: ColumnDef<Attribute, unknown> = {
   enableGlobalFilter: false,
   header: "Field",
   id: "field",
-  meta: { width: { max: "264px", min: "264px" } },
+  meta: {
+    width: {
+      min: "min(32%, 352px)", // TODO: update GridTrackSize to handle css functions min(), max().
+      max: "min(31%, 496px)",
+    } as unknown as GridTrackSize,
+  },
 };
 
 const NAME: ColumnDef<Attribute, unknown> = {


### PR DESCRIPTION
Closes #2787.

This pull request introduces layout enhancements and styling updates to improve the responsiveness and consistency of the `FieldCell` component and its associated table columns. The key changes involve adding reusable grid properties, wrapping specific elements in a `Grid` container, and updating column width definitions to use more dynamic sizing.

### Layout enhancements:

* [`components/DataDictionary/components/TableCell/components/FieldCell/constants.ts`](diffhunk://#diff-715cebab5c07891977a579c49dd63bc61bcdc449bc2de56a338f4a00bc7b2df6R1-R8): Introduced a new `GRID_PROPS` constant defining common grid properties for consistent layout usage.
* [`components/DataDictionary/components/TableCell/components/FieldCell/fieldCell.tsx`](diffhunk://#diff-cd3ea5c983342d18f6cdef697b3f41b5d0901fdc30cb8b33c8d62108aa05afa0R30): Updated the `FieldCell` component to wrap specific elements (e.g., `CodeCell`, `Chip`) in a `Grid` container using the newly introduced `GRID_PROPS` for better layout control. [[1]](diffhunk://#diff-cd3ea5c983342d18f6cdef697b3f41b5d0901fdc30cb8b33c8d62108aa05afa0R30) [[2]](diffhunk://#diff-cd3ea5c983342d18f6cdef697b3f41b5d0901fdc30cb8b33c8d62108aa05afa0R43)

### Styling updates:

* [`viewModelBuilders/dataDictionaryMapper/columnDefs.ts`](diffhunk://#diff-10495c94e0d5f47859e7500c12d18908a1478c7fdf0883b03b5535ac0b3a4c1aL48-R49): Adjusted column width definitions for `DETAILS` and `FIELD` to use more dynamic and responsive sizing, improving the table's adaptability to different screen sizes. [[1]](diffhunk://#diff-10495c94e0d5f47859e7500c12d18908a1478c7fdf0883b03b5535ac0b3a4c1aL48-R49) [[2]](diffhunk://#diff-10495c94e0d5f47859e7500c12d18908a1478c7fdf0883b03b5535ac0b3a4c1aL58-R62)

<img width="1923" height="1132" alt="image" src="https://github.com/user-attachments/assets/041e1e6c-4328-4f57-b3d5-ee79f138bc71" />
