### PR TITLE
feat: ui cleanup nits - tier 1 (#2804)

### DIFF
--- a/components/DataDictionary/components/TableCell/components/DetailCell/detailCell.tsx
+++ b/components/DataDictionary/components/TableCell/components/DetailCell/detailCell.tsx
@@ -9,7 +9,12 @@ import {
   StyledCollapse,
 } from "./detailCell.styles";
 import { LinkCell } from "@databiosphere/findable-ui/lib/components/Table/components/TableCell/components/LinkCell/linkCell";
-import { buildExample, buildSource, shouldShowTierColumn } from "./utils";
+import {
+  buildBioNetworks,
+  buildExample,
+  buildSource,
+  shouldShowTierColumn,
+} from "./utils";
 import { getPartialCellContext } from "../../utils";
 import { StyledMarkdownCell } from "./detailCell.styles";
 import { COLUMN_IDENTIFIERS } from "../../../../../../viewModelBuilders/dataDictionaryMapper/columnIds";
@@ -94,7 +99,7 @@ export const DetailCell = ({
             <Typography {...TYPOGRAPHY_PROPS}>BioNetworks</Typography>
             <StyledMarkdownCell
               {...getPartialCellContext(
-                (row.original.annotations?.bioNetworks as string[]).join(", "),
+                buildBioNetworks(table, row),
                 COLUMN_IDENTIFIERS.BIO_NETWORK
               )}
               row={row}

--- a/components/DataDictionary/components/TableCell/components/DetailCell/detailCell.tsx
+++ b/components/DataDictionary/components/TableCell/components/DetailCell/detailCell.tsx
@@ -9,7 +9,7 @@ import {
   StyledCollapse,
 } from "./detailCell.styles";
 import { LinkCell } from "@databiosphere/findable-ui/lib/components/Table/components/TableCell/components/LinkCell/linkCell";
-import { buildExample } from "./utils";
+import { buildExample, buildSource } from "./utils";
 import { getPartialCellContext } from "../../utils";
 import { StyledMarkdownCell } from "./detailCell.styles";
 import { COLUMN_IDENTIFIERS } from "../../../../../../viewModelBuilders/dataDictionaryMapper/columnIds";
@@ -74,7 +74,7 @@ export const DetailCell = ({
         )}
         <div>
           <Typography {...TYPOGRAPHY_PROPS}>Source</Typography>
-          <LinkCell {...getPartialCellContext(row.original.source)} />
+          <LinkCell {...getPartialCellContext(buildSource(row))} />
         </div>
         {row.original.annotations?.tier && (
           <div>

--- a/components/DataDictionary/components/TableCell/components/DetailCell/detailCell.tsx
+++ b/components/DataDictionary/components/TableCell/components/DetailCell/detailCell.tsx
@@ -9,7 +9,7 @@ import {
   StyledCollapse,
 } from "./detailCell.styles";
 import { LinkCell } from "@databiosphere/findable-ui/lib/components/Table/components/TableCell/components/LinkCell/linkCell";
-import { buildExample, buildSource } from "./utils";
+import { buildExample, buildSource, shouldShowTierColumn } from "./utils";
 import { getPartialCellContext } from "../../utils";
 import { StyledMarkdownCell } from "./detailCell.styles";
 import { COLUMN_IDENTIFIERS } from "../../../../../../viewModelBuilders/dataDictionaryMapper/columnIds";
@@ -76,7 +76,7 @@ export const DetailCell = ({
           <Typography {...TYPOGRAPHY_PROPS}>Source</Typography>
           <LinkCell {...getPartialCellContext(buildSource(row))} />
         </div>
-        {row.original.annotations?.tier && (
+        {shouldShowTierColumn(table, row) && (
           <div>
             <Typography {...TYPOGRAPHY_PROPS}>Tier</Typography>
             <StyledMarkdownCell

--- a/components/DataDictionary/components/TableCell/components/DetailCell/utils.ts
+++ b/components/DataDictionary/components/TableCell/components/DetailCell/utils.ts
@@ -4,6 +4,35 @@ import { COLUMN_IDENTIFIERS } from "../../../../../../viewModelBuilders/dataDict
 import { LinkProps } from "@mui/material";
 
 /**
+ * Build bioNetwork string from the given row.
+ * @param table - The table.
+ * @param row - The row.
+ * @returns The bioNetwork string.
+ */
+export function buildBioNetworks(
+  table: Table<Attribute>,
+  row: Row<Attribute>
+): string {
+  // Grab the bioNetwork value from the row.
+  const value = row.getValue(COLUMN_IDENTIFIERS.BIO_NETWORK);
+
+  // Grab the bioNetwork column from the table and get the number of unique values.
+  const column = table.getColumn(COLUMN_IDENTIFIERS.BIO_NETWORK);
+  const facetedCount = column?.getFacetedUniqueValues().size;
+
+  // If the value is an array, and the number of unique values is equal to the length of the array, return "All".
+  if (Array.isArray(value)) {
+    if (facetedCount === value.length) return "All";
+
+    // Otherwise, return the value joined by ", ".
+    return value.join(", ");
+  }
+
+  // Throw an error if the value is not an array.
+  throw new Error("Invalid bioNetwork value");
+}
+
+/**
  * Build example string array from the given attribute.
  * @param attribute - The attribute.
  * @returns The example string array.

--- a/components/DataDictionary/components/TableCell/components/DetailCell/utils.ts
+++ b/components/DataDictionary/components/TableCell/components/DetailCell/utils.ts
@@ -1,4 +1,4 @@
-import { Row } from "@tanstack/react-table";
+import { Row, Table } from "@tanstack/react-table";
 import { Attribute } from "../../../../../../viewModelBuilders/dataDictionaryMapper/types";
 import { COLUMN_IDENTIFIERS } from "../../../../../../viewModelBuilders/dataDictionaryMapper/columnIds";
 import { LinkProps } from "@mui/material";
@@ -23,4 +23,24 @@ export function buildSource(row: Row<Attribute>): LinkProps {
   const value = row.getValue(COLUMN_IDENTIFIERS.SOURCE);
   if (value === "HCA") return { children: "HCA", href: "" };
   return row.original.source;
+}
+
+/**
+ * Checks if the tier column is configured in the table, and tier is present in the annotations.
+ * @param table - The table.
+ * @param row - The row.
+ * @returns True if the tier column is configured and tier is present in the annotations, false otherwise.
+ */
+export function shouldShowTierColumn(
+  table: Table<Attribute>,
+  row: Row<Attribute>
+): boolean {
+  // Tier column is configured.
+  const isConfigured = table
+    .getAllColumns()
+    .some((col) => col.id === COLUMN_IDENTIFIERS.TIER);
+
+  if (!isConfigured) return false;
+
+  return Boolean(row.original.annotations?.tier);
 }

--- a/components/DataDictionary/components/TableCell/components/DetailCell/utils.ts
+++ b/components/DataDictionary/components/TableCell/components/DetailCell/utils.ts
@@ -1,4 +1,7 @@
+import { Row } from "@tanstack/react-table";
 import { Attribute } from "../../../../../../viewModelBuilders/dataDictionaryMapper/types";
+import { COLUMN_IDENTIFIERS } from "../../../../../../viewModelBuilders/dataDictionaryMapper/columnIds";
+import { LinkProps } from "@mui/material";
 
 /**
  * Build example string array from the given attribute.
@@ -8,4 +11,16 @@ import { Attribute } from "../../../../../../viewModelBuilders/dataDictionaryMap
 export function buildExample(attribute: Attribute): string[] {
   if (!attribute.example) return [];
   return attribute.example.split(";").map((value) => value.trim());
+}
+
+/**
+ * Build source LinkProps from the given row.
+ * Replaces LinkProps with HCA LinkProps for source value "HCA".
+ * @param row - The row.
+ * @returns LinkProps.
+ */
+export function buildSource(row: Row<Attribute>): LinkProps {
+  const value = row.getValue(COLUMN_IDENTIFIERS.SOURCE);
+  if (value === "HCA") return { children: "HCA", href: "" };
+  return row.original.source;
 }

--- a/components/DataDictionary/components/TableCell/components/FieldCell/utils.ts
+++ b/components/DataDictionary/components/TableCell/components/FieldCell/utils.ts
@@ -22,7 +22,7 @@ export function buildRequired(attribute: Attribute): ChipProps {
   const isRequired = Boolean(attribute.required);
   return {
     color: isRequired ? CHIP_PROPS.COLOR.ERROR : CHIP_PROPS.COLOR.DEFAULT,
-    label: isRequired ? "Required" : "Not Required",
+    label: isRequired ? "Required" : "Recommended",
     variant: "status",
   };
 }

--- a/routes/constants.ts
+++ b/routes/constants.ts
@@ -8,11 +8,9 @@ export const ROUTES = {
   HCA_BIONETWORKS: "/hca-bio-networks",
   HELP: "/help",
   METADATA: "/metadata",
-  METADATA_CELL_ANNOTATION_SCHEMA_ANN_DATA:
-    "/metadata/cell-annotation-schema-ann-data",
-  METADATA_TIER_1_SCHEMA_ANN_DATA: "/metadata/tier-1-schema-ann-data",
-  METADATA_TIER_2_SCHEMA_HCA_DATA_REPOSITORY:
-    "/metadata/tier-2-schema-hca-data-repository",
+  METADATA_CELL_ANNOTATION: "/metadata/cell-annotation",
+  METADATA_TIER_1: "/metadata/tier-1",
+  METADATA_TIER_2: "/metadata/tier-2",
   PRIVACY: "/privacy",
   SEARCH: "/search",
 };

--- a/site-config/data-portal/dev/config.ts
+++ b/site-config/data-portal/dev/config.ts
@@ -10,15 +10,15 @@ import { CONTRIBUTE } from "./navigation/contribute";
 import { GUIDES } from "./navigation/guides";
 import { socialMedia, SOCIALS } from "./socialMedia";
 import { themeOptions } from "./themeOptions";
-import cellAnnotationSchemaAnnData from "./dataDictionary/cell-annotation-schema-ann-data.json";
-import tier1SchemaAnnData from "./dataDictionary/tier-1-schema-ann-data.json";
-import tier2SchemaHcaDataRepository from "./dataDictionary/tier-2-schema-hca-data-repository.json";
+import cellAnnotation from "./dataDictionary/cell-annotation.json";
+import metadataTier1 from "./dataDictionary/tier-1.json";
+import metadataTier2 from "./dataDictionary/tier-2.json";
 import { buildDataDictionary } from "../../../viewModelBuilders/dataDictionaryMapper/dataDictionaryMapper";
 import { DataDictionaryConfig } from "@databiosphere/findable-ui/lib/common/entities";
 import {
-  CELL_ANNOTATION_SCHEMA_TABLE_OPTIONS,
-  TIER_1_SCHEMA_TABLE_OPTIONS,
-  TIER_2_SCHEMA_TABLE_OPTIONS,
+  CELL_ANNOTATION_TABLE_OPTIONS,
+  TIER_1_TABLE_OPTIONS,
+  TIER_2_TABLE_OPTIONS,
 } from "../../../viewModelBuilders/dataDictionaryMapper/tableOptions";
 import { SELECTED_MATCH } from "@databiosphere/findable-ui/lib/components/Layout/components/Header/common/entities";
 
@@ -55,19 +55,19 @@ export function makeConfig(
     },
     dataDictionaries: [
       {
-        dataDictionary: buildDataDictionary(tier1SchemaAnnData),
-        path: "tier-1-schema-ann-data",
-        tableOptions: TIER_1_SCHEMA_TABLE_OPTIONS,
+        dataDictionary: buildDataDictionary(metadataTier1),
+        path: "tier-1",
+        tableOptions: TIER_1_TABLE_OPTIONS,
       },
       {
-        dataDictionary: buildDataDictionary(tier2SchemaHcaDataRepository),
-        path: "tier-2-schema-hca-data-repository",
-        tableOptions: TIER_2_SCHEMA_TABLE_OPTIONS,
+        dataDictionary: buildDataDictionary(metadataTier2),
+        path: "tier-2",
+        tableOptions: TIER_2_TABLE_OPTIONS,
       },
       {
-        dataDictionary: buildDataDictionary(cellAnnotationSchemaAnnData),
-        path: "cell-annotation-schema-ann-data",
-        tableOptions: CELL_ANNOTATION_SCHEMA_TABLE_OPTIONS,
+        dataDictionary: buildDataDictionary(cellAnnotation),
+        path: "cell-annotation",
+        tableOptions: CELL_ANNOTATION_TABLE_OPTIONS,
       },
     ] as unknown as DataDictionaryConfig[],
     entities: [],
@@ -136,19 +136,19 @@ export function makeConfig(
                   url: ROUTES.METADATA,
                 },
                 {
-                  label: "Tier 1 Schema (AnnData)",
+                  label: "Tier 1 Metadata",
                   selectedMatch: SELECTED_MATCH.EQUALS,
-                  url: ROUTES.METADATA_TIER_1_SCHEMA_ANN_DATA,
+                  url: ROUTES.METADATA_TIER_1,
                 },
                 {
-                  label: "Tier 2 Schema (HCA Data Repository)",
+                  label: "Tier 2 Metadata",
                   selectedMatch: SELECTED_MATCH.EQUALS,
-                  url: ROUTES.METADATA_TIER_2_SCHEMA_HCA_DATA_REPOSITORY,
+                  url: ROUTES.METADATA_TIER_2,
                 },
                 {
-                  label: "Cell Annotation Schema (AnnData)",
+                  label: "Cell Annotation",
                   selectedMatch: SELECTED_MATCH.EQUALS,
-                  url: ROUTES.METADATA_CELL_ANNOTATION_SCHEMA_ANN_DATA,
+                  url: ROUTES.METADATA_CELL_ANNOTATION,
                 },
               ],
               url: "",

--- a/site-config/data-portal/dev/config.ts
+++ b/site-config/data-portal/dev/config.ts
@@ -146,7 +146,7 @@ export function makeConfig(
                   url: ROUTES.METADATA_TIER_2,
                 },
                 {
-                  label: "Cell Annotation",
+                  label: "Cell Annotation Metadata",
                   selectedMatch: SELECTED_MATCH.EQUALS,
                   url: ROUTES.METADATA_CELL_ANNOTATION,
                 },

--- a/site-config/data-portal/dev/dataDictionary/cell-annotation.json
+++ b/site-config/data-portal/dev/dataDictionary/cell-annotation.json
@@ -1,6 +1,6 @@
 {
-  "name": "cell_annotation_schema_ann_data",
-  "title": "Cell Annotation Schema (AnnData)",
+  "name": "cell_annotation",
+  "title": "Cell Annotation",
   "classes": [
     {
       "title": "Dataset",

--- a/site-config/data-portal/dev/dataDictionary/cell-annotation.json
+++ b/site-config/data-portal/dev/dataDictionary/cell-annotation.json
@@ -1,6 +1,6 @@
 {
   "name": "cell_annotation",
-  "title": "Cell Annotation",
+  "title": "Cell Annotation Metadata",
   "classes": [
     {
       "title": "Dataset",

--- a/site-config/data-portal/dev/dataDictionary/tier-1.json
+++ b/site-config/data-portal/dev/dataDictionary/tier-1.json
@@ -1690,7 +1690,7 @@
     }
   ],
   "prefixes": {
-    "cxg": "https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/5.2.0/schema.md"
+    "cxg": "https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/6.0.0/schema.md"
   },
   "annotations": {
     "cxg": "CELLxGENE Schema"

--- a/site-config/data-portal/dev/dataDictionary/tier-1.json
+++ b/site-config/data-portal/dev/dataDictionary/tier-1.json
@@ -1,7 +1,7 @@
 {
-  "name": "tier_1_schema_ann_data",
+  "name": "tier_1",
   "description": "## Introduction\n\nThe HCA Tier 1 Metadata schema is an AnnData schema that extends the CZ CELLxGENE schema with additional fields required for the integration and batch correction of multiple datasets into an atlas.",
-  "title": "Tier 1 Schema (AnnData)",
+  "title": "Tier 1 Metadata",
   "classes": [
     {
       "title": "Dataset",

--- a/site-config/data-portal/dev/dataDictionary/tier-2.json
+++ b/site-config/data-portal/dev/dataDictionary/tier-2.json
@@ -1,6 +1,6 @@
 {
-  "name": "tier_2_schema_hca_data_repository",
-  "title": "Tier 2 Schema (HCA Data Repository)",
+  "name": "tier_2",
+  "title": "Tier 2 Metadata",
   "classes": [
     {
       "title": "Donor",

--- a/viewModelBuilders/dataDictionaryMapper/accessorFn.ts
+++ b/viewModelBuilders/dataDictionaryMapper/accessorFn.ts
@@ -1,0 +1,17 @@
+import { Attribute } from "./types";
+
+/**
+ * Accessor function for source.
+ * @param row - Original row data.
+ * @returns Source row value.
+ */
+export function buildTier1Source(row: Attribute) {
+  const { source } = row;
+  const { children } = source;
+
+  // Return HCA if source is None.
+  if (children === "None") return "HCA";
+
+  // Return source otherwise.
+  return source.children;
+}

--- a/viewModelBuilders/dataDictionaryMapper/columnDefs.ts
+++ b/viewModelBuilders/dataDictionaryMapper/columnDefs.ts
@@ -89,7 +89,7 @@ const RATIONALE: ColumnDef<Attribute, unknown> = {
 };
 
 const REQUIRED: ColumnDef<Attribute, unknown> = {
-  accessorFn: (row) => (row.required ? "Required" : "Not Required"),
+  accessorFn: (row) => (row.required ? "Required" : "Recommended"),
   enableColumnFilter: true,
   enableGlobalFilter: false,
   enableHiding: false,

--- a/viewModelBuilders/dataDictionaryMapper/columnDefs.ts
+++ b/viewModelBuilders/dataDictionaryMapper/columnDefs.ts
@@ -158,7 +158,6 @@ export const TIER_1_COLUMN_DEFS: ColumnDef<Attribute, unknown>[] = [
   DETAILS,
   REQUIRED,
   BIO_NETWORK,
-  TIER,
   ANN_DATA_LOCATION,
   {
     ...SOURCE,

--- a/viewModelBuilders/dataDictionaryMapper/columnDefs.ts
+++ b/viewModelBuilders/dataDictionaryMapper/columnDefs.ts
@@ -134,10 +134,7 @@ const VALUES: ColumnDef<Attribute, unknown> = {
   id: COLUMN_IDENTIFIERS.VALUES,
 };
 
-export const CELL_ANNOTATION_SCHEMA_COLUMN_DEFS: ColumnDef<
-  Attribute,
-  unknown
->[] = [
+export const CELL_ANNOTATION_COLUMN_DEFS: ColumnDef<Attribute, unknown>[] = [
   CLASS_KEY,
   FIELD,
   DETAILS,
@@ -154,7 +151,7 @@ export const CELL_ANNOTATION_SCHEMA_COLUMN_DEFS: ColumnDef<
   VALUES,
 ];
 
-export const TIER_1_SCHEMA_COLUMN_DEFS: ColumnDef<Attribute, unknown>[] = [
+export const TIER_1_COLUMN_DEFS: ColumnDef<Attribute, unknown>[] = [
   CLASS_KEY,
   FIELD,
   DETAILS,
@@ -171,7 +168,7 @@ export const TIER_1_SCHEMA_COLUMN_DEFS: ColumnDef<Attribute, unknown>[] = [
   VALUES,
 ];
 
-export const TIER_2_SCHEMA_COLUMN_DEFS: ColumnDef<Attribute, unknown>[] = [
+export const TIER_2_COLUMN_DEFS: ColumnDef<Attribute, unknown>[] = [
   CLASS_KEY,
   FIELD,
   DETAILS,

--- a/viewModelBuilders/dataDictionaryMapper/columnDefs.ts
+++ b/viewModelBuilders/dataDictionaryMapper/columnDefs.ts
@@ -7,7 +7,7 @@ import { COLUMN_IDENTIFIERS } from "./columnIds";
 import { buildTier1Source } from "./accessorFn";
 
 const ANN_DATA_LOCATION: ColumnDef<Attribute, unknown> = {
-  accessorKey: "annotations.annDataLocation",
+  accessorFn: (row) => row.annotations?.annDataLocation,
   enableColumnFilter: true,
   enableGlobalFilter: false,
   header: "AnnData",

--- a/viewModelBuilders/dataDictionaryMapper/columnDefs.ts
+++ b/viewModelBuilders/dataDictionaryMapper/columnDefs.ts
@@ -4,6 +4,7 @@ import { FieldCell } from "../../components/DataDictionary/components/TableCell/
 import { DetailCell } from "../../components/DataDictionary/components/TableCell/components/DetailCell/detailCell";
 import { GridTrackSize } from "@databiosphere/findable-ui/lib/config/entities";
 import { COLUMN_IDENTIFIERS } from "./columnIds";
+import { buildTier1Source } from "./accessorFn";
 
 const ANN_DATA_LOCATION: ColumnDef<Attribute, unknown> = {
   accessorKey: "annotations.annDataLocation",
@@ -159,7 +160,10 @@ export const TIER_1_COLUMN_DEFS: ColumnDef<Attribute, unknown>[] = [
   BIO_NETWORK,
   TIER,
   ANN_DATA_LOCATION,
-  SOURCE,
+  {
+    ...SOURCE,
+    accessorFn: buildTier1Source,
+  },
   /* GLOBAL FILTERS */
   LOCATION_NAME,
   DESCRIPTION,

--- a/viewModelBuilders/dataDictionaryMapper/dataDictionaryMapper.ts
+++ b/viewModelBuilders/dataDictionaryMapper/dataDictionaryMapper.ts
@@ -1,6 +1,10 @@
 import { Attribute } from "./types";
 import { DataDictionary } from "@databiosphere/findable-ui/lib/common/entities";
-import { buildLocationName, buildSourceAttribute } from "./viewModelBuilders";
+import {
+  buildAnnotations,
+  buildLocationName,
+  buildSourceAttribute,
+} from "./viewModelBuilders";
 
 /**
  * Returns a data dictionary built from the given data dictionary.
@@ -18,6 +22,7 @@ export function buildDataDictionary(
         attributes: classData.attributes.map((attribute) => {
           return {
             ...attribute,
+            annotations: buildAnnotations(attribute),
             locationName: buildLocationName(attribute),
             source: buildSourceAttribute(dataDictionary, attribute),
           };

--- a/viewModelBuilders/dataDictionaryMapper/tableOptions.ts
+++ b/viewModelBuilders/dataDictionaryMapper/tableOptions.ts
@@ -1,16 +1,16 @@
 import { TableOptions } from "@tanstack/react-table";
 import { Attribute } from "./types";
 import {
-  TIER_2_SCHEMA_COLUMN_DEFS,
-  TIER_1_SCHEMA_COLUMN_DEFS,
-  CELL_ANNOTATION_SCHEMA_COLUMN_DEFS,
+  TIER_2_COLUMN_DEFS,
+  TIER_1_COLUMN_DEFS,
+  CELL_ANNOTATION_COLUMN_DEFS,
 } from "./columnDefs";
 
-export const CELL_ANNOTATION_SCHEMA_TABLE_OPTIONS: Omit<
+export const CELL_ANNOTATION_TABLE_OPTIONS: Omit<
   TableOptions<Attribute>,
   "data" | "getCoreRowModel"
 > = {
-  columns: CELL_ANNOTATION_SCHEMA_COLUMN_DEFS,
+  columns: CELL_ANNOTATION_COLUMN_DEFS,
   getRowId: (row) => row.name,
   initialState: {
     columnVisibility: {
@@ -30,11 +30,11 @@ export const CELL_ANNOTATION_SCHEMA_TABLE_OPTIONS: Omit<
   },
 };
 
-export const TIER_1_SCHEMA_TABLE_OPTIONS: Omit<
+export const TIER_1_TABLE_OPTIONS: Omit<
   TableOptions<Attribute>,
   "data" | "getCoreRowModel"
 > = {
-  columns: TIER_1_SCHEMA_COLUMN_DEFS,
+  columns: TIER_1_COLUMN_DEFS,
   getRowId: (row) => row.name,
   initialState: {
     columnVisibility: {
@@ -55,11 +55,11 @@ export const TIER_1_SCHEMA_TABLE_OPTIONS: Omit<
   },
 };
 
-export const TIER_2_SCHEMA_TABLE_OPTIONS: Omit<
+export const TIER_2_TABLE_OPTIONS: Omit<
   TableOptions<Attribute>,
   "data" | "getCoreRowModel"
 > = {
-  columns: TIER_2_SCHEMA_COLUMN_DEFS,
+  columns: TIER_2_COLUMN_DEFS,
   getRowId: (row) => row.name,
   initialState: {
     columnVisibility: {

--- a/viewModelBuilders/dataDictionaryMapper/tableOptions.ts
+++ b/viewModelBuilders/dataDictionaryMapper/tableOptions.ts
@@ -18,6 +18,7 @@ export const CELL_ANNOTATION_TABLE_OPTIONS: Omit<
       bioNetwork: false,
       classKey: true,
       description: false,
+      locationName: false,
       name: false,
       rationale: false,
       required: false,

--- a/viewModelBuilders/dataDictionaryMapper/tableOptions.ts
+++ b/viewModelBuilders/dataDictionaryMapper/tableOptions.ts
@@ -47,7 +47,6 @@ export const TIER_1_TABLE_OPTIONS: Omit<
       rationale: false,
       required: false,
       source: false,
-      tier: false,
       title: false,
       values: false,
     },

--- a/viewModelBuilders/dataDictionaryMapper/viewModelBuilders.ts
+++ b/viewModelBuilders/dataDictionaryMapper/viewModelBuilders.ts
@@ -6,6 +6,21 @@ import {
 import { LABEL } from "@databiosphere/findable-ui/lib/apis/azul/common/entities";
 
 /**
+ * Returns the annotations for a given attribute.
+ * Formats bioNetworks to be human-readable.
+ * @param attribute - The attribute.
+ * @returns The annotations.
+ */
+export function buildAnnotations(
+  attribute: BaseAttribute
+): Attribute["annotations"] {
+  return {
+    ...attribute.annotations,
+    bioNetworks: formatBioNetworks(attribute.annotations?.bioNetworks),
+  };
+}
+
+/**
  * Returns the displayable name `location.name` for a given attribute.
  * @param attribute - The attribute.
  * @returns The displayable name.
@@ -73,4 +88,29 @@ export function buildSourceAttribute(
 
   // Default if neither CXG nor CAP is found, or if attribute has no relevant annotations
   return { children: LABEL.NONE, href: "" };
+}
+
+/**
+ * Deslugifies a string and capitalizes the first letter of each word.
+ * @param str - The string to deslugify.
+ * @returns The deslugified string.
+ */
+function deslugify(str: string): string {
+  return str.replace(/-/g, " ").replace(/\b\w/g, (c) => c.toLocaleUpperCase());
+}
+
+/**
+ * Formats bioNetworks to be human-readable.
+ * @param bioNetworks - The bioNetworks to format.
+ * @returns The formatted bioNetworks.
+ */
+function formatBioNetworks(
+  bioNetworks: string | string[] | undefined
+): string | string[] | undefined {
+  if (!bioNetworks) return;
+
+  // Handle array of bioNetworks.
+  if (Array.isArray(bioNetworks)) return bioNetworks.map(deslugify);
+
+  return deslugify(bioNetworks);
 }


### PR DESCRIPTION
Closes #2804.

This pull request introduces several updates to improve data dictionary handling, enhance table cell rendering, and simplify metadata schema definitions. The most significant changes include the addition of utility functions for rendering and logic, renaming and restructuring metadata schema files, and updates to table configurations and routes.

### Enhancements to table cell rendering and logic:
* Added utility functions `buildBioNetworks`, `buildSource`, and `shouldShowTierColumn` to `detailCell.tsx` for improved rendering of BioNetworks, source links, and tier column visibility. These functions ensure consistent logic and formatting across components. [[1]](diffhunk://#diff-cbe692583bc6403a787f3e61e7eb6b3d40cd86c7762b41136f749594016cabe0R1-R33) [[2]](diffhunk://#diff-cbe692583bc6403a787f3e61e7eb6b3d40cd86c7762b41136f749594016cabe0R44-R75)
* Updated `DetailCell` in `detailCell.tsx` to use the new utility functions for rendering source, tier, and BioNetworks data. [[1]](diffhunk://#diff-069661689f0ee6c12fb3f5fcf9db40cb7bca4c2dfc90225fd01436a3861db732L77-R84) [[2]](diffhunk://#diff-069661689f0ee6c12fb3f5fcf9db40cb7bca4c2dfc90225fd01436a3861db732L97-R102)

### Metadata schema simplification:
* Renamed and restructured metadata schema files (`cell-annotation-schema-ann-data.json`, `tier-1-schema-ann-data.json`, and `tier-2-schema-hca-data-repository.json`) to shorter, more descriptive names (`cell-annotation.json`, `tier-1.json`, and `tier-2.json`). Updated corresponding references in `config.ts` and related files. [[1]](diffhunk://#diff-09ef054390a74b1d1efb29c244e8c637cf7a751ab4422b29358ef132d63e3c66L13-R21) [[2]](diffhunk://#diff-bbc31a1e997ebeae532f7a639a8cdd264079c9c861129912b4bb9f03b0c6b1aeL2-R3) [[3]](diffhunk://#diff-8064d9c6c6888b3534f537d4565774784405425f2bce7a90c6cc816885f42533L2-R4) [[4]](diffhunk://#diff-362cc12d7e59cce74161a4b940a57fb456cf022f36d0234ba4074041973f6749L2-R3)
* Updated metadata schema URLs and titles to reflect the new naming conventions and schema versions. [[1]](diffhunk://#diff-8064d9c6c6888b3534f537d4565774784405425f2bce7a90c6cc816885f42533L1693-R1693) [[2]](diffhunk://#diff-09ef054390a74b1d1efb29c244e8c637cf7a751ab4422b29358ef132d63e3c66L139-R151)

### Updates to table configurations:
* Replaced schema-specific column definitions and table options (e.g., `TIER_1_SCHEMA_COLUMN_DEFS`) with more generic and reusable alternatives (e.g., `TIER_1_COLUMN_DEFS`). Simplified accessor functions and removed unused columns like `tier`. [[1]](diffhunk://#diff-10495c94e0d5f47859e7500c12d18908a1478c7fdf0883b03b5535ac0b3a4c1aL157-R165) [[2]](diffhunk://#diff-0b80c4f1540c198908ac22c618a8c0b10348e81871855fb37757cf303c14530bL33-R37) [[3]](diffhunk://#diff-0b80c4f1540c198908ac22c618a8c0b10348e81871855fb37757cf303c14530bL50-R61)
* Updated the `buildRequired` accessor in `FieldCell/utils.ts` to label non-required fields as "Recommended" instead of "Not Required." [[1]](diffhunk://#diff-63f8c19af597ab9e604a5b5b942ea6fef1699f9852c58ccee2518035176f4c92L25-R25) [[2]](diffhunk://#diff-10495c94e0d5f47859e7500c12d18908a1478c7fdf0883b03b5535ac0b3a4c1aL92-R93)

### Route and navigation updates:
* Simplified metadata-related routes in `constants.ts` and updated navigation labels in `config.ts` to align with the new schema naming conventions. [[1]](diffhunk://#diff-7ebd9e98055eaac29228f42c33478b95f17575f8f3985c398ab07656c2f3cf3fL11-R13) [[2]](diffhunk://#diff-09ef054390a74b1d1efb29c244e8c637cf7a751ab4422b29358ef132d63e3c66L139-R151)

### Additional improvements:
* Added `buildTier1Source` accessor function to handle special cases for Tier 1 source values. Updated column definitions to use this function. [[1]](diffhunk://#diff-433bc95182bf578d3c679403f699df25cd144b38914d3cbf2480b972cf35803bR1-R17) [[2]](diffhunk://#diff-10495c94e0d5f47859e7500c12d18908a1478c7fdf0883b03b5535ac0b3a4c1aL157-R165)
* Introduced `buildAnnotations` to format BioNetworks annotations for improved readability.