### PR TITLE
feat: data dictionary - add library entity for Tier 1 metadta (#2805)

### DIFF
--- a/site-config/data-portal/dev/dataDictionary/tier-1.json
+++ b/site-config/data-portal/dev/dataDictionary/tier-1.json
@@ -1295,142 +1295,6 @@
             ],
             "tier": "Tier 1"
           },
-          "description": "The unique ID that is used to track libraries in the investigator's institution (should align with the publication).",
-          "example": "A24; NK_healthy_001",
-          "multivalued": false,
-          "name": "library_id",
-          "range": "string",
-          "rationale": "A way to track the unit of data generation. This should include sample pooling",
-          "required": true,
-          "title": "Library ID"
-        },
-        {
-          "annotations": {
-            "annDataLocation": "obs",
-            "bioNetworks": [
-              "adipose",
-              "breast",
-              "development",
-              "eye",
-              "genetic-diversity",
-              "gut",
-              "heart",
-              "immune",
-              "kidney",
-              "liver",
-              "lung",
-              "musculoskeletal",
-              "nervous-system",
-              "oral",
-              "organoid",
-              "pancreas",
-              "reproduction",
-              "skin"
-            ],
-            "tier": "Tier 1"
-          },
-          "description": "The unique ID used to track libraries from one of the following public data repositories: EGAX*, GSM*, SRX*, ERX*, DRX, HRX, CRX",
-          "example": "GSM1684095",
-          "multivalued": false,
-          "name": "library_id_repository",
-          "range": "string",
-          "rationale": "Links a dataset back to the source from which it was ingested, optional only if this is the same as the library_id.",
-          "required": false,
-          "title": "Library ID Repository"
-        },
-        {
-          "annotations": {
-            "annDataLocation": "obs",
-            "bioNetworks": [
-              "adipose",
-              "breast",
-              "development",
-              "eye",
-              "genetic-diversity",
-              "gut",
-              "heart",
-              "immune",
-              "kidney",
-              "liver",
-              "lung",
-              "musculoskeletal",
-              "nervous-system",
-              "oral",
-              "organoid",
-              "pancreas",
-              "reproduction",
-              "skin"
-            ],
-            "tier": "Tier 1"
-          },
-          "description": "Indicating which samples' libraries were prepared in the same chip/plate/etc., e.g. batch1, batch2.",
-          "example": "batch01; batch02",
-          "multivalued": false,
-          "name": "library_preparation_batch",
-          "range": "string",
-          "rationale": "Sample preparation is a major source of batch effects.",
-          "required": true,
-          "title": "Library Preparation Batch"
-        },
-        {
-          "annotations": {
-            "annDataLocation": "obs",
-            "bioNetworks": [
-              "adipose",
-              "breast",
-              "development",
-              "eye",
-              "genetic-diversity",
-              "gut",
-              "heart",
-              "immune",
-              "kidney",
-              "liver",
-              "lung",
-              "musculoskeletal",
-              "nervous-system",
-              "oral",
-              "organoid",
-              "pancreas",
-              "reproduction",
-              "skin"
-            ],
-            "tier": "Tier 1"
-          },
-          "description": "The identifier (or accession number) that indicates which samples' libraries were sequenced in the same run.",
-          "example": "run1; NV0087",
-          "multivalued": false,
-          "name": "library_sequencing_run",
-          "range": "string",
-          "rationale": "Library sequencing is a major source of batch effects",
-          "required": true,
-          "title": "Library Sequencing Run"
-        },
-        {
-          "annotations": {
-            "annDataLocation": "obs",
-            "bioNetworks": [
-              "adipose",
-              "breast",
-              "development",
-              "eye",
-              "genetic-diversity",
-              "gut",
-              "heart",
-              "immune",
-              "kidney",
-              "liver",
-              "lung",
-              "musculoskeletal",
-              "nervous-system",
-              "oral",
-              "organoid",
-              "pancreas",
-              "reproduction",
-              "skin"
-            ],
-            "tier": "Tier 1"
-          },
           "description": "The pseudonymised name of the site where the sample was collected.",
           "example": "AIDA_site_1; AIDA_site_2",
           "multivalued": false,
@@ -1610,6 +1474,149 @@
           "rationale": "Space for author intuition of batch effects in their dataset",
           "required": false,
           "title": "Author Batch Notes"
+        }
+      ]
+    },
+    {
+      "title": "Library",
+      "description": "",
+      "name": "library",
+      "attributes": [
+        {
+          "annotations": {
+            "annDataLocation": "obs",
+            "bioNetworks": [
+              "adipose",
+              "breast",
+              "development",
+              "eye",
+              "genetic-diversity",
+              "gut",
+              "heart",
+              "immune",
+              "kidney",
+              "liver",
+              "lung",
+              "musculoskeletal",
+              "nervous-system",
+              "oral",
+              "organoid",
+              "pancreas",
+              "reproduction",
+              "skin"
+            ],
+            "tier": "Tier 1"
+          },
+          "description": "The unique ID that is used to track libraries in the investigator's institution (should align with the publication).",
+          "example": "A24; NK_healthy_001",
+          "multivalued": false,
+          "name": "library_id",
+          "range": "string",
+          "rationale": "A way to track the unit of data generation. This should include sample pooling",
+          "required": true,
+          "title": "Library ID"
+        },
+        {
+          "annotations": {
+            "annDataLocation": "obs",
+            "bioNetworks": [
+              "adipose",
+              "breast",
+              "development",
+              "eye",
+              "genetic-diversity",
+              "gut",
+              "heart",
+              "immune",
+              "kidney",
+              "liver",
+              "lung",
+              "musculoskeletal",
+              "nervous-system",
+              "oral",
+              "organoid",
+              "pancreas",
+              "reproduction",
+              "skin"
+            ],
+            "tier": "Tier 1"
+          },
+          "description": "The unique ID used to track libraries from one of the following public data repositories: EGAX*, GSM*, SRX*, ERX*, DRX, HRX, CRX",
+          "example": "GSM1684095",
+          "multivalued": false,
+          "name": "library_id_repository",
+          "range": "string",
+          "rationale": "Links a dataset back to the source from which it was ingested, optional only if this is the same as the library_id.",
+          "required": false,
+          "title": "Library ID Repository"
+        },
+        {
+          "annotations": {
+            "annDataLocation": "obs",
+            "bioNetworks": [
+              "adipose",
+              "breast",
+              "development",
+              "eye",
+              "genetic-diversity",
+              "gut",
+              "heart",
+              "immune",
+              "kidney",
+              "liver",
+              "lung",
+              "musculoskeletal",
+              "nervous-system",
+              "oral",
+              "organoid",
+              "pancreas",
+              "reproduction",
+              "skin"
+            ],
+            "tier": "Tier 1"
+          },
+          "description": "Indicating which samples' libraries were prepared in the same chip/plate/etc., e.g. batch1, batch2.",
+          "example": "batch01; batch02",
+          "multivalued": false,
+          "name": "library_preparation_batch",
+          "range": "string",
+          "rationale": "Sample preparation is a major source of batch effects.",
+          "required": true,
+          "title": "Library Preparation Batch"
+        },
+        {
+          "annotations": {
+            "annDataLocation": "obs",
+            "bioNetworks": [
+              "adipose",
+              "breast",
+              "development",
+              "eye",
+              "genetic-diversity",
+              "gut",
+              "heart",
+              "immune",
+              "kidney",
+              "liver",
+              "lung",
+              "musculoskeletal",
+              "nervous-system",
+              "oral",
+              "organoid",
+              "pancreas",
+              "reproduction",
+              "skin"
+            ],
+            "tier": "Tier 1"
+          },
+          "description": "The identifier (or accession number) that indicates which samples' libraries were sequenced in the same run.",
+          "example": "run1; NV0087",
+          "multivalued": false,
+          "name": "library_sequencing_run",
+          "range": "string",
+          "rationale": "Library sequencing is a major source of batch effects",
+          "required": true,
+          "title": "Library Sequencing Run"
         }
       ]
     },


### PR DESCRIPTION
Closes #2805.

This pull request introduces significant updates to the `tier-1.json` data dictionary, primarily focused on renaming attributes, refining descriptions, and adjusting metadata to improve clarity and align with updated data tracking and quality requirements. The key themes include changes to attribute names, updates to descriptions and rationales, and adjustments to data requirements.

### Attribute Renaming and Reorganization:
* Renamed `library_id` to `sample_collection_site` and updated its description to reflect the pseudonymized site of sample collection instead of library tracking.
* Renamed `library_id_repository` to `sample_collection_relative_time_point` and revised its purpose to track relative time points for sample collection.
* Renamed `library_preparation_batch` to `cell_number_loaded` to focus on the estimated number of cells loaded for library construction.
* Renamed `library_sequencing_run` to `cell_viability_percentage` to capture cell viability as a quality measure.
* Renamed `sample_collection_site` to `institute` to indicate the institution where samples were processed.

### Description and Metadata Updates:
* Adjusted descriptions and examples for renamed attributes to align with their new purposes, such as clarifying the use of relative time points and pseudonymized site names. [[1]](diffhunk://#diff-8064d9c6c6888b3534f537d4565774784405425f2bce7a90c6cc816885f42533L1298-R1306) [[2]](diffhunk://#diff-8064d9c6c6888b3534f537d4565774784405425f2bce7a90c6cc816885f42533L1332-R1340)
* Updated rationales to reflect the importance of tracking batch effects, sample quality, and institutional processing for data analysis. [[1]](diffhunk://#diff-8064d9c6c6888b3534f537d4565774784405425f2bce7a90c6cc816885f42533L1366-R1374) [[2]](diffhunk://#diff-8064d9c6c6888b3534f537d4565774784405425f2bce7a90c6cc816885f42533L1434-R1442)

### Adjustments to Data Requirements:
* Changed several attributes from `required: true` to `required: false`, reflecting a shift in emphasis toward optional metadata fields. [[1]](diffhunk://#diff-8064d9c6c6888b3534f537d4565774784405425f2bce7a90c6cc816885f42533L1298-R1306) [[2]](diffhunk://#diff-8064d9c6c6888b3534f537d4565774784405425f2bce7a90c6cc816885f42533L1332-R1340)
* Added a new `values` field to `sample_collection_site` to provide guidance on creating unique identifiers for collection sites.

### Reverting and Reassigning Attributes:
* Reintroduced `library_id` and `library_id_repository` with their original purposes and descriptions, while removing their prior replacements. [[1]](diffhunk://#diff-8064d9c6c6888b3534f537d4565774784405425f2bce7a90c6cc816885f42533L1503-R1517) [[2]](diffhunk://#diff-8064d9c6c6888b3534f537d4565774784405425f2bce7a90c6cc816885f42533L1537-R1551)
* Reassigned `library_preparation_batch` and `library_sequencing_run` to their original roles, replacing the interim attributes. [[1]](diffhunk://#diff-8064d9c6c6888b3534f537d4565774784405425f2bce7a90c6cc816885f42533L1571-R1585) [[2]](diffhunk://#diff-8064d9c6c6888b3534f537d4565774784405425f2bce7a90c6cc816885f42533L1605-R1619) 

These changes ensure the data dictionary is more aligned with current data tracking needs and provides clearer guidance for users.

<img width="2057" height="1083" alt="image" src="https://github.com/user-attachments/assets/bff44dc4-84d4-4dd3-84b5-0e6e26409fb4" />
