### PR TITLE
content: data dictionary Introduction updates (#2803)

### DIFF
--- a/site-config/data-portal/dev/dataDictionary/cell-annotation.json
+++ b/site-config/data-portal/dev/dataDictionary/cell-annotation.json
@@ -1,5 +1,6 @@
 {
   "name": "cell_annotation",
+  "description": "## Introduction\n\nCell‑annotation metadata standardizes cell‑type labels. Stored on the [Cell Annotation Platform](https://celltype.info) (CAP), the schema records each cell’s ontology term, synonyms, and parent category. See the [CAP AnnData schema](https://github.com/cellannotation/cell-annotation-schema/blob/main/docs/cap_anndata_schema.md) for additional details.",
   "title": "Cell Annotation Metadata",
   "classes": [
     {

--- a/site-config/data-portal/dev/dataDictionary/tier-1.json
+++ b/site-config/data-portal/dev/dataDictionary/tier-1.json
@@ -1,6 +1,6 @@
 {
   "name": "tier_1",
-  "description": "## Introduction\n\nThe HCA Tier 1 Metadata schema is an AnnData schema that extends the CZ CELLxGENE schema with additional fields required for the integration and batch correction of multiple datasets into an atlas.",
+  "description": "## Introduction\n\nTier 1 metadata extends the [CELLxGENE AnnData schema](https://chanzuckerberg.github.io/single-cell-curation/latest-schema.html) with the batch, sample, and sequencing details needed for atlas‑level batch correction, QC, and cross‑dataset integration.",
   "title": "Tier 1 Metadata",
   "classes": [
     {

--- a/site-config/data-portal/dev/dataDictionary/tier-2.json
+++ b/site-config/data-portal/dev/dataDictionary/tier-2.json
@@ -1,5 +1,6 @@
 {
   "name": "tier_2",
+  "description": "## Introduction\n\nThe Tier 2 metadata provides richer donor- and sample-level context, such as age, clinical phenotype, treatment, and similar fields, used in downstream analysis. Because some fields may be identifying, Tier 2 metadata are collected and distributed under managed access. The Biological Networks group is finalizing the field list; drafts are in the [HCA Tier 2 Metadata Definitions](https://drive.google.com/drive/folders/1ngcIgKBV9OUM1pPO-CDRH6ZIpyiSpamu?usp=sharing) folder.",
   "title": "Tier 2 Metadata",
   "classes": [
     {


### PR DESCRIPTION
Closes #2803.

This pull request updates the descriptions in the metadata schema files to provide more detailed and standardized information about the schemas. The changes include adding links to relevant resources and clarifying the purpose and scope of each schema.

### Metadata schema description updates:

* [`site-config/data-portal/dev/dataDictionary/cell-annotation.json`](diffhunk://#diff-bbc31a1e997ebeae532f7a639a8cdd264079c9c861129912b4bb9f03b0c6b1aeR3): Added a detailed description of the cell annotation metadata, including its purpose, ontology term details, and links to the Cell Annotation Platform and schema documentation.

* [`site-config/data-portal/dev/dataDictionary/tier-1.json`](diffhunk://#diff-8064d9c6c6888b3534f537d4565774784405425f2bce7a90c6cc816885f42533L3-R3): Revised the description of the Tier 1 metadata to clarify its role in batch correction, QC, and integration across datasets, and included a link to the CELLxGENE AnnData schema.

* [`site-config/data-portal/dev/dataDictionary/tier-2.json`](diffhunk://#diff-362cc12d7e59cce74161a4b940a57fb456cf022f36d0234ba4074041973f6749R3): Added a new description for the Tier 2 metadata, explaining its focus on donor- and sample-level context, managed access, and a link to draft metadata definitions.

<img width="933" height="522" alt="image" src="https://github.com/user-attachments/assets/c69970ec-5985-42de-97b0-653d864b34b6" />

<img width="934" height="658" alt="image" src="https://github.com/user-attachments/assets/58870247-0c60-4214-b6d7-4ad8a4baac2d" />

<img width="934" height="744" alt="image" src="https://github.com/user-attachments/assets/d4d12f84-155d-4d4c-b1ce-be1467a10a42" />
