### PR TITLE
fix: bionetworks display of 'All' by hard coding the total number of bionetworks (#2815)

### DIFF
--- a/components/DataDictionary/components/TableCell/components/DetailCell/constants.ts
+++ b/components/DataDictionary/components/TableCell/components/DetailCell/constants.ts
@@ -1,6 +1,8 @@
 import { TYPOGRAPHY_PROPS as MUI_TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
 import { TypographyProps } from "@mui/material";
 
+export const BIO_NETWORK_COUNT = 18;
+
 export const TYPOGRAPHY_PROPS: TypographyProps = {
   component: "div",
   gutterBottom: true,

--- a/components/DataDictionary/components/TableCell/components/DetailCell/detailCell.tsx
+++ b/components/DataDictionary/components/TableCell/components/DetailCell/detailCell.tsx
@@ -99,7 +99,7 @@ export const DetailCell = ({
             <Typography {...TYPOGRAPHY_PROPS}>BioNetworks</Typography>
             <StyledMarkdownCell
               {...getPartialCellContext(
-                buildBioNetworks(table, row),
+                buildBioNetworks(row),
                 COLUMN_IDENTIFIERS.BIO_NETWORK
               )}
               row={row}

--- a/components/DataDictionary/components/TableCell/components/DetailCell/utils.ts
+++ b/components/DataDictionary/components/TableCell/components/DetailCell/utils.ts
@@ -2,27 +2,20 @@ import { Row, Table } from "@tanstack/react-table";
 import { Attribute } from "../../../../../../viewModelBuilders/dataDictionaryMapper/types";
 import { COLUMN_IDENTIFIERS } from "../../../../../../viewModelBuilders/dataDictionaryMapper/columnIds";
 import { LinkProps } from "@mui/material";
+import { BIO_NETWORK_COUNT } from "./constants";
 
 /**
  * Build bioNetwork string from the given row.
- * @param table - The table.
  * @param row - The row.
  * @returns The bioNetwork string.
  */
-export function buildBioNetworks(
-  table: Table<Attribute>,
-  row: Row<Attribute>
-): string {
+export function buildBioNetworks(row: Row<Attribute>): string {
   // Grab the bioNetwork value from the row.
   const value = row.getValue(COLUMN_IDENTIFIERS.BIO_NETWORK);
 
-  // Grab the bioNetwork column from the table and get the number of unique values.
-  const column = table.getColumn(COLUMN_IDENTIFIERS.BIO_NETWORK);
-  const facetedCount = column?.getFacetedUniqueValues().size;
-
   // If the value is an array, and the number of unique values is equal to the length of the array, return "All".
   if (Array.isArray(value)) {
-    if (facetedCount === value.length) return "All";
+    if (value.length === BIO_NETWORK_COUNT) return "All";
 
     // Otherwise, return the value joined by ", ".
     return value.join(", ");


### PR DESCRIPTION
Closes #2815.

This pull request refactors the `buildBioNetworks` function in the `DetailCell` component by simplifying its logic and introducing a new constant for bio-network count. It removes the dependency on the `table` parameter and replaces it with a static value, streamlining the code and improving maintainability.

### Refactoring of `buildBioNetworks` function:

* [`components/DataDictionary/components/TableCell/components/DetailCell/utils.ts`](diffhunk://#diff-cbe692583bc6403a787f3e61e7eb6b3d40cd86c7762b41136f749594016cabe0R5-R18): Removed the `table` parameter from the `buildBioNetworks` function and replaced the dynamic faceted count logic with the static `BIO_NETWORK_COUNT` constant. This simplifies the function and reduces dependency on the table structure.

### Introduction of `BIO_NETWORK_COUNT` constant:

* [`components/DataDictionary/components/TableCell/components/DetailCell/constants.ts`](diffhunk://#diff-fa3d8dd6a7873003bc21fbc72eb2ae8da5dbf3ca6b4b2ffd847476d44ef82f89R4-R5): Added a new constant `BIO_NETWORK_COUNT` with a value of 18 to represent the expected number of bio-networks. This is now used in the `buildBioNetworks` function.

### Update to `DetailCell` component:

* [`components/DataDictionary/components/TableCell/components/DetailCell/detailCell.tsx`](diffhunk://#diff-069661689f0ee6c12fb3f5fcf9db40cb7bca4c2dfc90225fd01436a3861db732L102-R102): Updated the `buildBioNetworks` function call to remove the `table` parameter, aligning with the refactored function signature.