### PR TITLE
chore: update findable-ui to latest version 41.1.0 (#2817)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "next",
       "version": "2.5.0",
       "dependencies": {
-        "@databiosphere/findable-ui": "^41.0.0",
+        "@databiosphere/findable-ui": "^41.1.0",
         "@emotion/react": "^11.13.3",
         "@emotion/styled": "^11.13.0",
         "@mdx-js/loader": "^3.0.1",
@@ -560,9 +560,9 @@
       }
     },
     "node_modules/@databiosphere/findable-ui": {
-      "version": "41.0.0",
-      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-41.0.0.tgz",
-      "integrity": "sha512-oSLF2vwSu/hhYDDrvB6vALioiDlNezRuLMKGKdn2kaONPEbkaTkZxiiUKSfVDBoaOMrscGHlPHsxZBgy7uEf4A==",
+      "version": "41.1.0",
+      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-41.1.0.tgz",
+      "integrity": "sha512-WKgt/ht+8e+n5YB2IqzPZbXOyOai8OM1MMIEH6DIU5uCpwf7kDSObJduqF3+Z/WnXdU1dmsC53O71tqOW//olg==",
       "engines": {
         "node": "20.10.0"
       },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "get-cellxgene-projects": "esrun ./scripts/get-cellxgene-projects.ts"
   },
   "dependencies": {
-    "@databiosphere/findable-ui": "^41.0.0",
+    "@databiosphere/findable-ui": "^41.1.0",
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
     "@mdx-js/loader": "^3.0.1",


### PR DESCRIPTION
Closes #2817.

This pull request includes a minor update to the `package.json` file. The change upgrades the `@databiosphere/findable-ui` dependency from version `^41.0.0` to `^41.1.0` to include the latest features and bug fixes.