### PR TITLE
content: cell Annotation metadata content review (#2819)

### DIFF
--- a/components/DataDictionary/components/TableCell/components/DetailCell/detailCell.tsx
+++ b/components/DataDictionary/components/TableCell/components/DetailCell/detailCell.tsx
@@ -14,7 +14,6 @@ import {
   buildExample,
   buildSource,
   shouldShowAnnDataLocationColumn,
-  shouldShowTierColumn,
 } from "./utils";
 import { getPartialCellContext } from "../../utils";
 import { StyledMarkdownCell } from "./detailCell.styles";
@@ -82,19 +81,6 @@ export const DetailCell = ({
           <Typography {...TYPOGRAPHY_PROPS}>Source</Typography>
           <LinkCell {...getPartialCellContext(buildSource(row))} />
         </div>
-        {shouldShowTierColumn(table, row) && (
-          <div>
-            <Typography {...TYPOGRAPHY_PROPS}>Tier</Typography>
-            <StyledMarkdownCell
-              {...getPartialCellContext(
-                row.original.annotations?.tier as string,
-                COLUMN_IDENTIFIERS.TIER
-              )}
-              row={row}
-              table={table}
-            />
-          </div>
-        )}
         {row.original.annotations?.bioNetworks && (
           <div>
             <Typography {...TYPOGRAPHY_PROPS}>BioNetworks</Typography>

--- a/components/DataDictionary/components/TableCell/components/DetailCell/utils.ts
+++ b/components/DataDictionary/components/TableCell/components/DetailCell/utils.ts
@@ -62,23 +62,3 @@ export function shouldShowAnnDataLocationColumn(
 
   return isConfigured;
 }
-
-/**
- * Checks if the tier column is configured in the table, and tier is present in the annotations.
- * @param table - Table.
- * @param row - Row.
- * @returns True if the tier column is configured and tier is present in the annotations, false otherwise.
- */
-export function shouldShowTierColumn(
-  table: Table<Attribute>,
-  row: Row<Attribute>
-): boolean {
-  // Tier column is configured.
-  const isConfigured = table
-    .getAllColumns()
-    .some((col) => col.id === COLUMN_IDENTIFIERS.TIER);
-
-  if (!isConfigured) return false;
-
-  return Boolean(row.original.annotations?.tier);
-}

--- a/site-config/data-portal/dev/dataDictionary/cell-annotation.json
+++ b/site-config/data-portal/dev/dataDictionary/cell-annotation.json
@@ -601,7 +601,7 @@
           "range": "string",
           "required": true,
           "title": "Description",
-          "values": "This is free-text for collaborators and third-parties to understand the context/background for the creation of this cell annotation set."
+          "values": "This is free-text for collaborators and third-parties to understand the context/background for the creation of this cell annotation set.\n\nWe STRONGLY recommend this field be descriptive for other scientists unfamiliar with this project to understand why this set of cell annotations exist."
         },
         {
           "annotations": {
@@ -629,7 +629,7 @@
             "cap": "annotation_method",
             "tier": "Cell Annotation"
           },
-          "description": "",
+          "description": "Method used for cell annotation.",
           "example": "algorithmic;manual;both",
           "multivalued": true,
           "name": "{cellannotation_setname}.annotation_method",

--- a/site-config/data-portal/dev/dataDictionary/cell-annotation.json
+++ b/site-config/data-portal/dev/dataDictionary/cell-annotation.json
@@ -41,7 +41,7 @@
           "range": "integer",
           "required": false,
           "title": "Clustering",
-          "values": "_Column Name_\n\nThe column name is `cluster`, `leiden`, `louvain` or `cluster + _ + [ALGORITHM_TYPE] + _ + [SUFFIX]` whereby [ALGORITHM_TYPE] and [SUFFIX] are OPTIONAL.\n\n* `cluster`, `leiden` or `louvain`: MUST be used to denote clustering in AnnData.obs\n\n* [ALGORITHM]: Denotes the algorithm used, e.g. be either `leiden` or `louvain`. OPTIONAL.\n\n* [SUFFIX]: Denotes a descriptive tag informative enough for third-party users; used to distinguish between multiple clusterings. OPTIONAL\n\n<br>Example field names: `cluster_leiden`, `cluster_leiden_broad`, `louvain`, `leiden_fine`.\n\n_Cluster_\n\nInteger of cluster label. "
+          "values": "_Column Name_\n\nThe column name is `cluster`, `leiden`, `louvain` or `cluster + _ + [ALGORITHM_TYPE] + _ + [SUFFIX]` whereby [ALGORITHM_TYPE] and [SUFFIX] are OPTIONAL.\n\n* `cluster`, `leiden` or `louvain`: MUST be used to denote clustering in AnnData.obs\n\n* [ALGORITHM]: Denotes the algorithm used, e.g. be either `leiden` or `louvain`. OPTIONAL.\n\n* [SUFFIX]: Denotes a descriptive tag informative enough for third-party users; used to distinguish between multiple clusterings. OPTIONAL.\n\nExample field names: `cluster_leiden`, `cluster_leiden_broad`, `louvain`, `leiden_fine`.\n\n_Cluster_\n\nInteger of cluster label."
         },
         {
           "annotations": {
@@ -76,7 +76,7 @@
           "range": "string",
           "required": true,
           "title": "Cell Annotation Set Name",
-          "values": "_Column Name_\n\nThe column name is the string`[cellannotation_setname]` and the values are the strings of `cell_label`. Refer to the fields `cellannotation_setname` and `cell_label` in the JSON Schema.\n\n_Set Name_\n\nAny free-text term which the author uses to annotate cells, the preferred cell label name used by the author."
+          "values": "_Column Name_\n\nThe column name is the string `[cellannotation_setname]` and the values are the strings of `cell_label`. Refer to the fields `cellannotation_setname` and `cell_label` in the JSON Schema.\n\n_Set Name_\n\nAny free-text term which the author uses to annotate cells, the preferred cell label name used by the author."
         },
         {
           "annotations": {
@@ -104,7 +104,7 @@
             "cap": "cellannotation_setname--cell_fullname",
             "tier": "Cell Annotation"
           },
-          "description": "The column name is the value `[cellannotation_setname]` concatenated with the string `'cell_fullname'` and two hyphens, i.e. `[cellannotation_setname] + '--' + 'cell_fullname'`\n\nFor example, if the user specified the cell annotation as `broad_cells1`, then the name of the column in the pandas DataFrame will be `broad_cells1--cell_fullname`.",
+          "description": "The column name is the value `[cellannotation_setname]` concatenated with the string `'cell_fullname'` and two hyphens, i.e. `[cellannotation_setname] + '--' + 'cell_fullname'`.\n\nFor example, if the user specified the cell annotation as `broad_cells1`, then the name of the column in the pandas DataFrame will be `broad_cells1--cell_fullname`.",
           "example": "rod bipolar",
           "multivalued": true,
           "name": "{cellannotation_setname}--cell_fullname",
@@ -139,7 +139,7 @@
             "cap": "cellannotation_setname--cell_ontology_exists",
             "tier": "Cell Annotation"
           },
-          "description": "The column name is the string prefix `[cellannotation_setname]--` concatenated with the string value `cell_ontology_exists`, i.e. `[cellannotation_setname] + '--' + 'cell_ontology_exists'`",
+          "description": "The column name is the string prefix `[cellannotation_setname]--` concatenated with the string value `cell_ontology_exists`, i.e. `[cellannotation_setname] + '--' + 'cell_ontology_exists'`.",
           "example": "True",
           "multivalued": true,
           "name": "{cellannotation_setname}--cell_ontology_exists",
@@ -174,7 +174,7 @@
             "cap": "cellannotation_setname--cell_ontology_term_id",
             "tier": "Cell Annotation"
           },
-          "description": "The column name is the value `[cellannotation_setname]` concatenated with the string `'cell_ontology_term_id'` and two hyphens, i.e. `[cellannotation_setname] + '--' + 'cell_ontology_term_id'`",
+          "description": "The column name is the value `[cellannotation_setname]` concatenated with the string `'cell_ontology_term_id'` and two hyphens, i.e. `[cellannotation_setname] + '--' + 'cell_ontology_term_id'`.",
           "example": "CL:0000751",
           "multivalued": true,
           "name": "{cellannotation_setname}--cell_ontology_term_id",
@@ -209,7 +209,7 @@
             "cap": "cellannotation_setname--cell_ontology_term",
             "tier": "Cell Annotation"
           },
-          "description": "The column name is the value `[cellannotation_setname]` concatenated with the string `'cell_ontology_term'` and two hyphens, i.e. `[cellannotation_setname] + '--' + 'cell_ontology_term'`",
+          "description": "The column name is the value `[cellannotation_setname]` concatenated with the string `'cell_ontology_term'` and two hyphens, i.e. `[cellannotation_setname] + '--' + 'cell_ontology_term'`.",
           "example": "rod bipolar cell",
           "multivalued": true,
           "name": "{cellannotation_setname}--cell_ontology_term",
@@ -244,14 +244,14 @@
             "cap": "cellannotation_setname--rationale",
             "tier": "Cell Annotation"
           },
-          "description": "The column name is the value `[cellannotation_setname]` concatenated with the string `'rationale'` and two hyphens, i.e. `[cellannotation_setname] + '--' + 'rationale'`",
+          "description": "The column name is the value `[cellannotation_setname]` concatenated with the string `'rationale'` and two hyphens, i.e. `[cellannotation_setname] + '--' + 'rationale'`.",
           "example": "This cell was annotated with [blank] given the canonical markers in the field [X], [Y], [Z]. We noticed [X] and [Y] running differential expression.",
           "multivalued": true,
           "name": "{cellannotation_setname}--rationale",
           "range": "string",
           "required": true,
           "title": "Rationale",
-          "values": ""
+          "values": "The free-text rationale which users provide as justification/evidence for their cell annotations."
         },
         {
           "annotations": {
@@ -279,7 +279,7 @@
             "cap": "cellannotation_setname--rationale_dois",
             "tier": "Cell Annotation"
           },
-          "description": "The column name is the value `[cellannotation_setname]` concatenated with the string `'rationale_dois'` and two hyphens, i.e. `[cellannotation_setname] + '--' + 'rationale_dois'`",
+          "description": "The column name is the value `[cellannotation_setname]` concatenated with the string `'rationale_dois'` and two hyphens, i.e. `[cellannotation_setname] + '--' + 'rationale_dois'`.",
           "example": "10.1038/s41587-022-01468-y, 10.1038/s41556-021-00787-7, 10.1038/s41586-021-03465-8",
           "multivalued": true,
           "name": "{cellannotation_setname}--rationale_dois",
@@ -314,7 +314,7 @@
             "cap": "cellannotation_setname--marker_gene_evidence",
             "tier": "Cell Annotation"
           },
-          "description": "The column name is the value `[cellannotation_setname]` concatenated with the string `'marker_gene_evidence'` and two hyphens, i.e. `[cellannotation_setname] + '--' + 'marker_gene_evidence'`\n\nFor example, if the user specified the cell annotation as `broad_cells1`, then the name of the column in the pandas DataFrame will be `broad_cells1--marker_gene_evidence`.",
+          "description": "The column name is the value `[cellannotation_setname]` concatenated with the string `'marker_gene_evidence'` and two hyphens, i.e. `[cellannotation_setname] + '--' + 'marker_gene_evidence'`.",
           "example": "TP53, KRAS, BRCA1",
           "multivalued": true,
           "name": "{cellannotation_setname}--marker_gene_evidence",
@@ -349,7 +349,7 @@
             "cap": "cellannotation_setname--canonical_marker_genes",
             "tier": "Cell Annotation"
           },
-          "description": "The column name is the value `[cellannotation_setname]` concatenated with the string `'canonical_marker_genes'` and two hyphens, i.e. `[cellannotation_setname] + '--' + 'canonical_marker_genes'`\n\nFor example, if the user specified the cell annotation as `broad_cells1`, then the name of the column in the pandas DataFrame will be `broad_cells1--canonical_marker_genes`.",
+          "description": "The column name is the value `[cellannotation_setname]` concatenated with the string `'canonical_marker_genes'` and two hyphens, i.e. `[cellannotation_setname] + '--' + 'canonical_marker_genes'`.",
           "example": "GATA3, CD3D, CD3E",
           "multivalued": true,
           "name": "{cellannotation_setname}--canonical_marker_genes",
@@ -384,7 +384,7 @@
             "cap": "cellannotation_setname--synonyms",
             "tier": "Cell Annotation"
           },
-          "description": "The column name is the value `[cellannotation_setname]` concatenated with the string `'synonyms'` and two hyphens, i.e. `[cellannotation_setname] + '--' + 'synonyms'`\n\nFor example, if the user specified the cell annotation as `broad_cells1`, then the name of the column in the pandas DataFrame will be `broad_cells1--synonyms`.",
+          "description": "The column name is the value `[cellannotation_setname]` concatenated with the string `'synonyms'` and two hyphens, i.e. `[cellannotation_setname] + '--' + 'synonyms'`.",
           "example": "neuroglial cell, glial cell, neuroglia; amacrine cell; FMB cell",
           "multivalued": true,
           "name": "{cellannotation_setname}--synonyms",
@@ -454,7 +454,7 @@
             "cap": "cellannotation_setname--category_cell_ontology_exists",
             "tier": "Cell Annotation"
           },
-          "description": "The column name is the string prefix `[cellannotation_setname]--` concatenated with the string value `category_cell_ontology_exists`, i.e. `[cellannotation_setname] + '--' + 'category_cell_ontology_exists'`",
+          "description": "The column name is the string prefix `[cellannotation_setname]--` concatenated with the string value `category_cell_ontology_exists`, i.e. `[cellannotation_setname] + '--' + 'category_cell_ontology_exists'`.",
           "example": "True",
           "multivalued": true,
           "name": "{cellannotation_setname}--category_cell_ontology_exists",
@@ -489,7 +489,7 @@
             "cap": "cellannotation_setname--category_cell_ontology_term_id",
             "tier": "Cell Annotation"
           },
-          "description": "The column name is the value `[cellannotation_setname]` concatenated with the string `'category_cell_ontology_term_id'` and two hyphens, i.e. `[cellannotation_setname] + '--' + 'category_cell_ontology_term_id'`",
+          "description": "The column name is the value `[cellannotation_setname]` concatenated with the string `'category_cell_ontology_term_id'` and two hyphens, i.e. `[cellannotation_setname] + '--' + 'category_cell_ontology_term_id'`.",
           "example": "CL:0000749",
           "multivalued": true,
           "name": "{cellannotation_setname}--category_cell_ontology_term_id",
@@ -524,7 +524,7 @@
             "cap": "cellannotation_setname--category_cell_ontology_term",
             "tier": "Cell Annotation"
           },
-          "description": "The column name is the string prefix `[cellannotation_setname]--` concatenated with the string value `category_cell_ontology_term`, i.e. `[cellannotation_setname] + '--' + 'category_cell_ontology_term'`",
+          "description": "The column name is the string prefix `[cellannotation_setname]--` concatenated with the string value `category_cell_ontology_term`, i.e. `[cellannotation_setname] + '--' + 'category_cell_ontology_term'`.",
           "example": "ON-bipolar cell",
           "multivalued": true,
           "name": "{cellannotation_setname}--category_cell_ontology_term",

--- a/viewModelBuilders/dataDictionaryMapper/columnDefs.ts
+++ b/viewModelBuilders/dataDictionaryMapper/columnDefs.ts
@@ -110,16 +110,6 @@ const SOURCE: ColumnDef<Attribute, unknown> = {
   id: COLUMN_IDENTIFIERS.SOURCE,
 };
 
-const TIER: ColumnDef<Attribute, unknown> = {
-  accessorFn: (row) => row.annotations?.tier,
-  enableColumnFilter: false,
-  enableGlobalFilter: false,
-  enableHiding: false,
-  filterFn: "arrIncludesSome",
-  header: "Tier",
-  id: COLUMN_IDENTIFIERS.TIER,
-};
-
 const TITLE: ColumnDef<Attribute, unknown> = {
   accessorKey: "title",
   enableColumnFilter: false,
@@ -141,10 +131,9 @@ export const CELL_ANNOTATION_COLUMN_DEFS: ColumnDef<Attribute, unknown>[] = [
   FIELD,
   DETAILS,
   REQUIRED,
-  BIO_NETWORK,
-  TIER,
+  { ...BIO_NETWORK, enableColumnFilter: false },
   ANN_DATA_LOCATION,
-  SOURCE,
+  { ...SOURCE, enableColumnFilter: false },
   /* GLOBAL FILTERS */
   LOCATION_NAME,
   DESCRIPTION,

--- a/viewModelBuilders/dataDictionaryMapper/columnIds.ts
+++ b/viewModelBuilders/dataDictionaryMapper/columnIds.ts
@@ -10,7 +10,6 @@ export const COLUMN_IDENTIFIERS = {
   RATIONALE: "rationale",
   REQUIRED: "required",
   SOURCE: "source",
-  TIER: "tier",
   TITLE: "title",
   VALUES: "values",
 };

--- a/viewModelBuilders/dataDictionaryMapper/tableOptions.ts
+++ b/viewModelBuilders/dataDictionaryMapper/tableOptions.ts
@@ -23,7 +23,6 @@ export const CELL_ANNOTATION_TABLE_OPTIONS: Omit<
       rationale: false,
       required: false,
       source: false,
-      tier: false,
       title: false,
       values: false,
     },


### PR DESCRIPTION
Closes #2819.

This pull request updates the `cell-annotation.json` file in the data dictionary to improve clarity and consistency in descriptions and values. The changes primarily involve the removal of redundant line breaks, the addition of missing punctuation, and the enhancement of value descriptions for better readability.

### Improvements to descriptions:
* Standardized descriptions by adding missing periods at the end of sentences across multiple fields, such as `cell_ontology_exists`, `rationale`, and `marker_gene_evidence` (`[[1]](diffhunk://#diff-bbc31a1e997ebeae532f7a639a8cdd264079c9c861129912b4bb9f03b0c6b1aeL142-R142)`, `[[2]](diffhunk://#diff-bbc31a1e997ebeae532f7a639a8cdd264079c9c861129912b4bb9f03b0c6b1aeL247-R254)`, `[[3]](diffhunk://#diff-bbc31a1e997ebeae532f7a639a8cdd264079c9c861129912b4bb9f03b0c6b1aeL317-R317)`).
* Removed redundant line breaks in descriptions to improve readability and maintain formatting consistency (`[[1]](diffhunk://#diff-bbc31a1e997ebeae532f7a639a8cdd264079c9c861129912b4bb9f03b0c6b1aeL44-R44)`, `[[2]](diffhunk://#diff-bbc31a1e997ebeae532f7a639a8cdd264079c9c861129912b4bb9f03b0c6b1aeL107-R107)`, `[[3]](diffhunk://#diff-bbc31a1e997ebeae532f7a639a8cdd264079c9c861129912b4bb9f03b0c6b1aeL352-R352)`).

### Enhancements to value fields:
* Updated the `values` field for the `rationale` property to include a meaningful description, replacing the previously empty string (`[site-config/data-portal/dev/dataDictionary/cell-annotation.jsonL247-R254](diffhunk://#diff-bbc31a1e997ebeae532f7a639a8cdd264079c9c861129912b4bb9f03b0c6b1aeL247-R254)`).