### PR TITLE
content: data dictionary var and x adjustments (#2821)

### DIFF
--- a/components/DataDictionary/components/TableCell/components/DetailCell/detailCell.tsx
+++ b/components/DataDictionary/components/TableCell/components/DetailCell/detailCell.tsx
@@ -10,6 +10,7 @@ import {
 } from "./detailCell.styles";
 import { LinkCell } from "@databiosphere/findable-ui/lib/components/Table/components/TableCell/components/LinkCell/linkCell";
 import {
+  buildAnnDataLocation,
   buildBioNetworks,
   buildExample,
   buildSource,
@@ -99,7 +100,7 @@ export const DetailCell = ({
             <Typography {...TYPOGRAPHY_PROPS}>AnnData Location</Typography>
             <StyledMarkdownCell
               {...getPartialCellContext(
-                (row.original.annotations?.annDataLocation as string) || "None",
+                buildAnnDataLocation(row),
                 COLUMN_IDENTIFIERS.ANN_DATA_LOCATION
               )}
               row={row}

--- a/components/DataDictionary/components/TableCell/components/DetailCell/utils.ts
+++ b/components/DataDictionary/components/TableCell/components/DetailCell/utils.ts
@@ -5,6 +5,22 @@ import { LinkProps } from "@mui/material";
 import { BIO_NETWORK_COUNT } from "./constants";
 
 /**
+ * Build annDataLocation string from the given row.
+ * @param row - The row.
+ * @returns The annDataLocation string.
+ */
+export function buildAnnDataLocation(row: Row<Attribute>): string {
+  const value = row.getValue(COLUMN_IDENTIFIERS.ANN_DATA_LOCATION);
+
+  if (Array.isArray(value)) {
+    if (value.length === 0) return "None";
+    return value.join(" or ");
+  }
+
+  throw new Error("Invalid annDataLocation value");
+}
+
+/**
  * Build bioNetwork string from the given row.
  * @param row - Row.
  * @returns The bioNetwork string.

--- a/components/DataDictionary/components/TableCell/components/FieldCell/fieldCell.tsx
+++ b/components/DataDictionary/components/TableCell/components/FieldCell/fieldCell.tsx
@@ -2,7 +2,7 @@ import { CellContext } from "@tanstack/react-table";
 import { Attribute } from "../../../../../../viewModelBuilders/dataDictionaryMapper/types";
 import { Chip, Grid } from "@mui/material";
 import { StyledGrid } from "./fieldCell.styles";
-import { buildRequired, buildRange } from "./utils";
+import { buildRequired, buildRange, buildLocationName } from "./utils";
 import { CodeCell } from "@databiosphere/findable-ui/lib/components/Table/components/TableCell/components/CodeCell/codeCell";
 import { MarkdownCell } from "@databiosphere/findable-ui/lib/components/Table/components/TableCell/components/MarkdownCell/markdownCell";
 import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
@@ -41,18 +41,21 @@ export const FieldCell = ({
       </StyledTypography>
       <Grid {...GRID_PROPS}>
         {/* NAME */}
-        <CodeCell
-          {...getPartialCellContext(
-            <MarkdownCell
-              {...getPartialCellContext(
-                row.original.locationName,
-                COLUMN_IDENTIFIERS.LOCATION_NAME
-              )}
-              row={row}
-              table={table}
-            />
-          )}
-        />
+        {buildLocationName(row).map((name) => (
+          <CodeCell
+            key={name}
+            {...getPartialCellContext(
+              <MarkdownCell
+                {...getPartialCellContext(
+                  name,
+                  COLUMN_IDENTIFIERS.LOCATION_NAME
+                )}
+                row={row}
+                table={table}
+              />
+            )}
+          />
+        ))}
         {/* REQUIRED */}
         {row.original.required && <Chip {...buildRequired(row.original)} />}
       </Grid>

--- a/components/DataDictionary/components/TableCell/components/FieldCell/fieldCell.tsx
+++ b/components/DataDictionary/components/TableCell/components/FieldCell/fieldCell.tsx
@@ -12,6 +12,7 @@ import { getPartialCellContext } from "../../utils";
 import { AnchorLink } from "@databiosphere/findable-ui/lib/components/common/AnchorLink/anchorLink";
 import { StyledTypography } from "./fieldCell.styles";
 import { RankedCell } from "@databiosphere/findable-ui/lib/components/Table/components/TableCell/components/RankedCell/rankedCell";
+import slugify from "slugify";
 
 export const FieldCell = ({
   row,
@@ -33,7 +34,7 @@ export const FieldCell = ({
           table={table}
         >
           <AnchorLink
-            anchorLink={row.original.name}
+            anchorLink={slugify(row.original.name)}
             onClick={(e) => e.stopPropagation()}
           />
         </RankedCell>

--- a/components/DataDictionary/components/TableCell/components/FieldCell/utils.ts
+++ b/components/DataDictionary/components/TableCell/components/FieldCell/utils.ts
@@ -1,6 +1,16 @@
 import { ChipProps } from "@mui/material";
 import { Attribute } from "../../../../../../viewModelBuilders/dataDictionaryMapper/types";
 import { CHIP_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/chip";
+import { Row } from "@tanstack/react-table";
+
+/**
+ * Builds string array from the given attribute, for locationName.
+ * @param row - Row.
+ * @returns The location name string array.
+ */
+export function buildLocationName(row: Row<Attribute>): string[] {
+  return row.original.locationName.split(";").map((value) => value.trim());
+}
 
 /**
  * Builds string from the given attribute, for range and multivalued.

--- a/site-config/data-portal/dev/dataDictionary/tier-1.json
+++ b/site-config/data-portal/dev/dataDictionary/tier-1.json
@@ -1754,7 +1754,7 @@
           "description": "The data stored in the X data matrix is the data that is viewable in CELLxGENE Explorer.",
           "example": "",
           "multivalued": false,
-          "name": "X",
+          "name": "X; raw.X",
           "range": "oneOf(numpy.ndarray, scipy.sparse.csr_matrix)",
           "required": true,
           "title": "Matrix Layer",

--- a/site-config/data-portal/dev/dataDictionary/tier-1.json
+++ b/site-config/data-portal/dev/dataDictionary/tier-1.json
@@ -457,76 +457,6 @@
         },
         {
           "annotations": {
-            "annDataLocation": "X",
-            "bioNetworks": [
-              "adipose",
-              "breast",
-              "development",
-              "eye",
-              "genetic-diversity",
-              "gut",
-              "heart",
-              "immune",
-              "kidney",
-              "liver",
-              "lung",
-              "musculoskeletal",
-              "nervous-system",
-              "oral",
-              "organoid",
-              "pancreas",
-              "reproduction",
-              "skin"
-            ],
-            "cxg": "x-matrix-layers",
-            "tier": "Tier 1"
-          },
-          "description": "The data stored in the X data matrix is the data that is viewable in CELLxGENE Explorer.",
-          "example": "",
-          "multivalued": false,
-          "name": "X",
-          "range": "oneOf(numpy.ndarray, scipy.sparse.csr_matrix)",
-          "required": true,
-          "title": "Normalized Expression Matrix",
-          "values": "In any layer, if a matrix has 50% or more values that are zeros, it is STRONGLY RECOMMENDED that the matrix be encoded as a [`scipy.sparse.csr_matrix`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.csr_matrix.html).\n\nCELLxGENE's matrix layer requirements are tailored to optimize data reuse. Because each assay has different characteristics, the requirements differ by assay type. In general, CELLxGENE requires submission of \"raw\" data suitable for computational reuse when a standard raw matrix format exists for an assay. It is STRONGLY RECOMMENDED to also include a \"normalized\" matrix with processed values ready for data analysis and suitable for visualization in CELLxGENE Explorer. So that CELLxGENE's data can be provided in download formats suitable for both R and Python, the schema imposes the following requirements:\n\n* All matrix layers MUST have the same shape, and have the same cell labels and gene labels.\n* Because it is impractical to retain all barcodes in raw and normalized matrices, any cell filtering MUST be applied to both. By contrast, those wishing to reuse datasets require access to raw gene expression values, so genes SHOULD NOT be filtered from either dataset. Summarizing, any cell barcodes that are removed from the data MUST be filtered from both raw and normalized matrices and genes SHOULD NOT be filtered from the raw matrix.\n* Any genes that publishers wish to filter from the normalized matrix MAY have their values replaced by zeros and MUST be flagged in the column [feature_is_filtered](https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/4.0.0/schema.md#feature_is_filtered) of [var](https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/4.0.0/schema.md#var-and-rawvar-gene-metadata), which will mask them from exploration.\n* Additional layers provided at author discretion MAY be stored using author-selected keys, but MUST have the same cells and genes as other layers. It is STRONGLY RECOMMENDED that these layers have names that accurately summarize what the numbers in the layer represent (e.g. \"counts_per_million\", \"SCTransform_normalized\", or \"RNA_velocity_unspliced\").\n\nThe following table describes the matrix data and layers requirements that are **assay-specific**. If an entry in the table is empty, the schema does not have any other requirements on data in those layers beyond the ones listed above.\n\n| Assay | \"raw\" required? | \"raw\" location | \"normalized\" required? | \"normalized\" location |\n|-|-|-|-|-|\n| scRNA-seq (UMI, e.g. 10x v3) | REQUIRED. Values MUST be de-duplicated molecule counts. Each cell MUST contain at least one non-zero value. All non-zero values MUST be positive integers stored as `numpy.float32`.| `AnnData.raw.X` unless no \"normalized\" is provided, then `AnnData.X` | STRONGLY RECOMMENDED | `AnnData.X` |\n| scRNA-seq (non-UMI, e.g. SS2) | REQUIRED. Values MUST be one of read counts (e.g. FeatureCounts) or  estimated fragments (e.g. output of RSEM). Each cell MUST contain at least one non-zero value. All non-zero values MUST be positive integers stored as `numpy.float32`. | `AnnData.raw.X` unless no \"normalized\" is provided, then `AnnData.X` | STRONGLY RECOMMENDED | `AnnData.X` |\n| Accessibility (e.g. ATAC-seq, mC-seq) | NOT REQUIRED | | REQUIRED | `AnnData.X` | STRONGLY RECOMMENDED |"
-        },
-        {
-          "annotations": {
-            "annDataLocation": "raw.X",
-            "bioNetworks": [
-              "adipose",
-              "breast",
-              "development",
-              "eye",
-              "genetic-diversity",
-              "gut",
-              "heart",
-              "immune",
-              "kidney",
-              "liver",
-              "lung",
-              "musculoskeletal",
-              "nervous-system",
-              "oral",
-              "organoid",
-              "pancreas",
-              "reproduction",
-              "skin"
-            ],
-            "cxg": "x-matrix-layers",
-            "tier": "Tier 1"
-          },
-          "description": "The data stored in the X data matrix is the data that is viewable in CELLxGENE Explorer.",
-          "example": "",
-          "multivalued": false,
-          "name": "raw.X",
-          "range": "oneOf(numpy.ndarray, scipy.sparse.csr_matrix)",
-          "required": true,
-          "title": "Raw Expression Matrix",
-          "values": "In any layer, if a matrix has 50% or more values that are zeros, it is STRONGLY RECOMMENDED that the matrix be encoded as a [`scipy.sparse.csr_matrix`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.csr_matrix.html).\n\nCELLxGENE's matrix layer requirements are tailored to optimize data reuse. Because each assay has different characteristics, the requirements differ by assay type. In general, CELLxGENE requires submission of \"raw\" data suitable for computational reuse when a standard raw matrix format exists for an assay. It is STRONGLY RECOMMENDED to also include a \"normalized\" matrix with processed values ready for data analysis and suitable for visualization in CELLxGENE Explorer. So that CELLxGENE's data can be provided in download formats suitable for both R and Python, the schema imposes the following requirements:\n\n* All matrix layers MUST have the same shape, and have the same cell labels and gene labels.\n* Because it is impractical to retain all barcodes in raw and normalized matrices, any cell filtering MUST be applied to both. By contrast, those wishing to reuse datasets require access to raw gene expression values, so genes SHOULD NOT be filtered from either dataset. Summarizing, any cell barcodes that are removed from the data MUST be filtered from both raw and normalized matrices and genes SHOULD NOT be filtered from the raw matrix.\n* Any genes that publishers wish to filter from the normalized matrix MAY have their values replaced by zeros and MUST be flagged in the column [feature_is_filtered](https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/4.0.0/schema.md#feature_is_filtered) of [var](https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/4.0.0/schema.md#var-and-rawvar-gene-metadata), which will mask them from exploration.\n* Additional layers provided at author discretion MAY be stored using author-selected keys, but MUST have the same cells and genes as other layers. It is STRONGLY RECOMMENDED that these layers have names that accurately summarize what the numbers in the layer represent (e.g. \"counts_per_million\", \"SCTransform_normalized\", or \"RNA_velocity_unspliced\").\n\nThe following table describes the matrix data and layers requirements that are assay-specific. If an entry in the table is empty, the schema does not have any other requirements on data in those layers beyond the ones listed above.\n\n| Assay | \"raw\" required? | \"raw\" location | \"normalized\" required? | \"normalized\" location |\n|-|-|-|-|-|\n| scRNA-seq (UMI, e.g. 10x v3) | REQUIRED. Values MUST be de-duplicated molecule counts. Each cell MUST contain at least one non-zero value. All non-zero values MUST be positive integers stored as `numpy.float32`.| `AnnData.raw.X` unless no \"normalized\" is provided, then `AnnData.X` | STRONGLY RECOMMENDED | `AnnData.X` |\n| scRNA-seq (non-UMI, e.g. SS2) | REQUIRED. Values MUST be one of read counts (e.g. FeatureCounts) or  estimated fragments (e.g. output of RSEM). Each cell MUST contain at least one non-zero value. All non-zero values MUST be positive integers stored as `numpy.float32`. | `AnnData.raw.X` unless no \"normalized\" is provided, then `AnnData.X` | STRONGLY RECOMMENDED | `AnnData.X` |\n| Accessibility (e.g. ATAC-seq, mC-seq) | NOT REQUIRED | | REQUIRED | `AnnData.X` | STRONGLY RECOMMENDED |"
-        },
-        {
-          "annotations": {
             "annDataLocation": "uns",
             "bioNetworks": ["gut"],
             "tier": "Tier 1"
@@ -1710,6 +1640,125 @@
           "required": true,
           "title": "Cell Type Ontology Term ID",
           "values": "This must be a Cell Ontology (CL) term (http://www.ebi.ac.uk/ols4/ontologies/cl).\n\n If no appropriate high-level term can be found or the cell type is unknown, then it is strongly recommended to use 'unknown'.\n\n The following terms must not be used: \"CL:0000255\" for eukaryotic cell; \"CL:0000257\" for Eumycetozoan cell; \"CL:0000548\" for animal cell."
+        }
+      ]
+    },
+    {
+      "title": "Feature",
+      "description": "",
+      "name": "feature",
+      "attributes": [
+        {
+          "annotations": {
+            "annDataLocation": "var; raw.var",
+            "bioNetworks": [
+              "adipose",
+              "breast",
+              "development",
+              "eye",
+              "genetic-diversity",
+              "gut",
+              "heart",
+              "immune",
+              "kidney",
+              "liver",
+              "lung",
+              "musculoskeletal",
+              "nervous-system",
+              "oral",
+              "organoid",
+              "pancreas",
+              "reproduction",
+              "skin"
+            ],
+            "cxg": "index-of-pandasdataframe-1",
+            "tier": "Tier 1"
+          },
+          "description": "If the feature is a gene then this MUST be an ENSEMBL term. If the feature is a RNA Spike-In Control Mix then this MUST be an ERCC Spike-In identifier (e.g. `\"ERCC-0003\"`).\n\nThe index of the `pandas.DataFrame` MUST contain unique identifiers for features. If present, the index of raw.var MUST be identical to the index of var.",
+          "example": "",
+          "multivalued": false,
+          "name": "index of pandas.DataFrame",
+          "range": "string",
+          "rationale": "",
+          "required": true,
+          "title": "Feature ID"
+        },
+        {
+          "annotations": {
+            "annDataLocation": "var; raw.var",
+            "bioNetworks": [
+              "adipose",
+              "breast",
+              "development",
+              "eye",
+              "genetic-diversity",
+              "gut",
+              "heart",
+              "immune",
+              "kidney",
+              "liver",
+              "lung",
+              "musculoskeletal",
+              "nervous-system",
+              "oral",
+              "organoid",
+              "pancreas",
+              "reproduction",
+              "skin"
+            ],
+            "cxg": "feature_is_filtered",
+            "tier": "Tier 1"
+          },
+          "description": "This MUST be `True` if the feature was filtered out in the normalized matrix (`X`) but is present in the raw matrix (`raw.X`). The value for all cells of the given feature in the normalized matrix MUST be `0`.\n\nOtherwise, this MUST be `False`.",
+          "example": "",
+          "multivalued": false,
+          "name": "feature_is_filtered",
+          "range": "boolean",
+          "rationale": "",
+          "required": true,
+          "title": "Feature is Filtered"
+        }
+      ]
+    },
+    {
+      "title": "Matrix Layers",
+      "description": "",
+      "name": "matrixLayers",
+      "attributes": [
+        {
+          "annotations": {
+            "annDataLocation": "X; raw.X",
+            "bioNetworks": [
+              "adipose",
+              "breast",
+              "development",
+              "eye",
+              "genetic-diversity",
+              "gut",
+              "heart",
+              "immune",
+              "kidney",
+              "liver",
+              "lung",
+              "musculoskeletal",
+              "nervous-system",
+              "oral",
+              "organoid",
+              "pancreas",
+              "reproduction",
+              "skin"
+            ],
+            "cxg": "x-matrix-layers",
+            "tier": "Tier 1"
+          },
+          "description": "The data stored in the X data matrix is the data that is viewable in CELLxGENE Explorer.",
+          "example": "",
+          "multivalued": false,
+          "name": "X",
+          "range": "oneOf(numpy.ndarray, scipy.sparse.csr_matrix)",
+          "required": true,
+          "title": "Matrix Layer",
+          "values": "In any layer, if a matrix has 50% or more values that are zeros, it is STRONGLY RECOMMENDED that the matrix be encoded as a [`scipy.sparse.csr_matrix`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.csr_matrix.html).\n\nCELLxGENE's matrix layer requirements are tailored to optimize data reuse. Because each assay has different characteristics, the requirements differ by assay type. In general, CELLxGENE requires submission of \"raw\" data suitable for computational reuse when a standard raw matrix format exists for an assay. It is STRONGLY RECOMMENDED to also include a \"normalized\" matrix with processed values ready for data analysis and suitable for visualization in CELLxGENE Explorer. So that CELLxGENE's data can be provided in download formats suitable for both R and Python, the schema imposes the following requirements:\n\n* All matrix layers MUST have the same shape, and have the same cell labels and gene labels.\n* Because it is impractical to retain all barcodes in raw and normalized matrices, any cell filtering MUST be applied to both. By contrast, those wishing to reuse datasets require access to raw gene expression values, so genes SHOULD NOT be filtered from either dataset. Summarizing, any cell barcodes that are removed from the data MUST be filtered from both raw and normalized matrices and genes SHOULD NOT be filtered from the raw matrix.\n* Any genes that publishers wish to filter from the normalized matrix MAY have their values replaced by zeros and MUST be flagged in the column [feature_is_filtered](https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/4.0.0/schema.md#feature_is_filtered) of [var](https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/4.0.0/schema.md#var-and-rawvar-gene-metadata), which will mask them from exploration.\n* Additional layers provided at author discretion MAY be stored using author-selected keys, but MUST have the same cells and genes as other layers. It is STRONGLY RECOMMENDED that these layers have names that accurately summarize what the numbers in the layer represent (e.g. \"counts_per_million\", \"SCTransform_normalized\", or \"RNA_velocity_unspliced\").\n\nThe following table describes the matrix data and layers requirements that are assay-specific. If an entry in the table is empty, the schema does not have any other requirements on data in those layers beyond the ones listed above.\n\n| Assay | \"raw\" required? | \"raw\" location | \"normalized\" required? | \"normalized\" location |\n|-|-|-|-|-|\n| scRNA-seq (UMI, e.g. 10x v3) | REQUIRED. Values MUST be de-duplicated molecule counts. Each cell MUST contain at least one non-zero value. All non-zero values MUST be positive integers stored as `numpy.float32`.| `AnnData.raw.X` unless no \"normalized\" is provided, then `AnnData.X` | STRONGLY RECOMMENDED | `AnnData.X` |\n| scRNA-seq (non-UMI, e.g. SS2) | REQUIRED. Values MUST be one of read counts (e.g. FeatureCounts) or  estimated fragments (e.g. output of RSEM). Each cell MUST contain at least one non-zero value. All non-zero values MUST be positive integers stored as `numpy.float32`. | `AnnData.raw.X` unless no \"normalized\" is provided, then `AnnData.X` | STRONGLY RECOMMENDED | `AnnData.X` |\n| Accessibility (e.g. ATAC-seq, mC-seq) | NOT REQUIRED | | REQUIRED | `AnnData.X` | STRONGLY RECOMMENDED |"
         }
       ]
     }

--- a/viewModelBuilders/dataDictionaryMapper/accessorFn.ts
+++ b/viewModelBuilders/dataDictionaryMapper/accessorFn.ts
@@ -1,6 +1,20 @@
 import { Attribute } from "./types";
 
 /**
+ * Accessor function for annDataLocation.
+ * @param row - Original row data.
+ * @returns AnnDataLocation row value.
+ */
+export function buildAnnDataLocation(row: Attribute): string[] {
+  const originalValue = row.annotations?.annDataLocation;
+  if (!originalValue) return [];
+  // Split the annDataLocation string by ";" and trim each value.
+  if (typeof originalValue === "string")
+    return originalValue.split(";").map((s) => s.trim());
+  throw new Error("AnnDataLocation must be a string");
+}
+
+/**
  * Accessor function for source.
  * @param row - Original row data.
  * @returns Source row value.

--- a/viewModelBuilders/dataDictionaryMapper/columnDefs.ts
+++ b/viewModelBuilders/dataDictionaryMapper/columnDefs.ts
@@ -4,10 +4,10 @@ import { FieldCell } from "../../components/DataDictionary/components/TableCell/
 import { DetailCell } from "../../components/DataDictionary/components/TableCell/components/DetailCell/detailCell";
 import { GridTrackSize } from "@databiosphere/findable-ui/lib/config/entities";
 import { COLUMN_IDENTIFIERS } from "./columnIds";
-import { buildTierNSource } from "./accessorFn";
+import { buildTierNSource, buildAnnDataLocation } from "./accessorFn";
 
 const ANN_DATA_LOCATION: ColumnDef<Attribute, unknown> = {
-  accessorFn: (row) => row.annotations?.annDataLocation,
+  accessorFn: buildAnnDataLocation,
   enableColumnFilter: true,
   enableGlobalFilter: false,
   header: "AnnData",

--- a/viewModelBuilders/dataDictionaryMapper/tableOptions.ts
+++ b/viewModelBuilders/dataDictionaryMapper/tableOptions.ts
@@ -5,13 +5,14 @@ import {
   TIER_1_COLUMN_DEFS,
   CELL_ANNOTATION_COLUMN_DEFS,
 } from "./columnDefs";
+import slugify from "slugify";
 
 export const CELL_ANNOTATION_TABLE_OPTIONS: Omit<
   TableOptions<Attribute>,
   "data" | "getCoreRowModel"
 > = {
   columns: CELL_ANNOTATION_COLUMN_DEFS,
-  getRowId: (row) => row.name,
+  getRowId: (row) => slugify(row.name),
   initialState: {
     columnVisibility: {
       annDataLocation: false,
@@ -35,7 +36,7 @@ export const TIER_1_TABLE_OPTIONS: Omit<
   "data" | "getCoreRowModel"
 > = {
   columns: TIER_1_COLUMN_DEFS,
-  getRowId: (row) => row.name,
+  getRowId: (row) => slugify(row.name),
   initialState: {
     columnVisibility: {
       annDataLocation: false,
@@ -59,7 +60,7 @@ export const TIER_2_TABLE_OPTIONS: Omit<
   "data" | "getCoreRowModel"
 > = {
   columns: TIER_2_COLUMN_DEFS,
-  getRowId: (row) => row.name,
+  getRowId: (row) => slugify(row.name),
   initialState: {
     columnVisibility: {
       bioNetwork: false,

--- a/viewModelBuilders/dataDictionaryMapper/viewModelBuilders.ts
+++ b/viewModelBuilders/dataDictionaryMapper/viewModelBuilders.ts
@@ -32,8 +32,8 @@ export function buildLocationName(attribute: BaseAttribute): string {
   // Return attribute name if no annDataLocation is found.
   if (!annDataLocation) return attribute.name;
 
-  // Special case for X and raw.X.
-  if (annDataLocation === "X" || annDataLocation === "raw.X") {
+  // Special case for X and raw.X, and var and raw.var.
+  if (annDataLocation === "X; raw.X" || annDataLocation === "var; raw.var") {
     return attribute.name;
   }
 


### PR DESCRIPTION
Closes #2821.

This pull request introduces enhancements to the handling of `AnnDataLocation` values, improves row identification with slugified names, and updates the data dictionary schema. Key changes include the addition of a utility function to process `AnnDataLocation`, the use of `slugify` for consistent row IDs, and schema updates to refine data organization.

### Enhancements to `AnnDataLocation` Handling:
* Added a utility function `buildAnnDataLocation` to process `AnnDataLocation` values, ensuring proper formatting and handling of arrays or invalid data (`utils.ts`, `accessorFn.ts`). [[1]](diffhunk://#diff-cbe692583bc6403a787f3e61e7eb6b3d40cd86c7762b41136f749594016cabe0R7-R22) [[2]](diffhunk://#diff-433bc95182bf578d3c679403f699df25cd144b38914d3cbf2480b972cf35803bR3-R16)
* Updated `DetailCell` to use the new `buildAnnDataLocation` function for rendering `AnnDataLocation` values (`detailCell.tsx`).
* Modified column definitions to utilize the `buildAnnDataLocation` accessor function (`columnDefs.ts`).

### Improved Row Identification:
* Replaced row identifiers with slugified names across multiple table configurations to ensure consistent and unique row IDs (`tableOptions.ts`, `fieldCell.tsx`). [[1]](diffhunk://#diff-0b80c4f1540c198908ac22c618a8c0b10348e81871855fb37757cf303c14530bR8-R15) [[2]](diffhunk://#diff-cd3ea5c983342d18f6cdef697b3f41b5d0901fdc30cb8b33c8d62108aa05afa0L36-R37)

### Updates to Data Dictionary Schema:
* Removed outdated `X` and `raw.X` attributes and added new entries for "Feature" and "Matrix Layers" to better align with current data requirements (`tier-1.json`). [[1]](diffhunk://#diff-8064d9c6c6888b3534f537d4565774784405425f2bce7a90c6cc816885f42533L459-L528) [[2]](diffhunk://#diff-8064d9c6c6888b3534f537d4565774784405425f2bce7a90c6cc816885f42533R1646-R1764)
* Adjusted logic in `buildLocationName` to handle new `AnnDataLocation` cases like `var; raw.var` (`viewModelBuilders.ts`).

<img width="851" height="1254" alt="image" src="https://github.com/user-attachments/assets/b7823a7b-58ce-48eb-9b6a-b75cd67600df" />

<img width="851" height="1257" alt="image" src="https://github.com/user-attachments/assets/621b7e89-f1d8-465b-84e6-c4d52af4ae4a" />

