### PR TITLE
fix: remove test data from tier 1 data dictionary json (#2824)

### DIFF
--- a/site-config/data-portal/dev/dataDictionary/tier-1.json
+++ b/site-config/data-portal/dev/dataDictionary/tier-1.json
@@ -39,8 +39,7 @@
           "name": "study_pi",
           "range": "string",
           "required": true,
-          "title": "Study PI",
-          "values": "| test | test | test |\n| -- | -- | -- |\n| A test | B test | C test |"
+          "title": "Study PI"
         },
         {
           "annotations": {


### PR DESCRIPTION
Closes #2824.

This pull request includes a minor update to the `tier-1.json` file in the data portal configuration. The change simplifies the `values` field for the `study_pi` attribute by removing its table content.

* [`site-config/data-portal/dev/dataDictionary/tier-1.json`](diffhunk://#diff-8064d9c6c6888b3534f537d4565774784405425f2bce7a90c6cc816885f42533L42-R42): Removed the `values` field content for the `study_pi` attribute, leaving only the `title` field.