### PR TITLE
feat: tier 2 metadata content review (#2820)

### DIFF
--- a/components/DataDictionary/components/TableCell/components/DetailCell/detailCell.tsx
+++ b/components/DataDictionary/components/TableCell/components/DetailCell/detailCell.tsx
@@ -13,6 +13,7 @@ import {
   buildBioNetworks,
   buildExample,
   buildSource,
+  shouldShowAnnDataLocationColumn,
   shouldShowTierColumn,
 } from "./utils";
 import { getPartialCellContext } from "../../utils";
@@ -107,17 +108,19 @@ export const DetailCell = ({
             />
           </div>
         )}
-        <div>
-          <Typography {...TYPOGRAPHY_PROPS}>AnnData Location</Typography>
-          <StyledMarkdownCell
-            {...getPartialCellContext(
-              (row.original.annotations?.annDataLocation as string) || "None",
-              COLUMN_IDENTIFIERS.ANN_DATA_LOCATION
-            )}
-            row={row}
-            table={table}
-          />
-        </div>
+        {shouldShowAnnDataLocationColumn(table) && (
+          <div>
+            <Typography {...TYPOGRAPHY_PROPS}>AnnData Location</Typography>
+            <StyledMarkdownCell
+              {...getPartialCellContext(
+                (row.original.annotations?.annDataLocation as string) || "None",
+                COLUMN_IDENTIFIERS.ANN_DATA_LOCATION
+              )}
+              row={row}
+              table={table}
+            />
+          </div>
+        )}
       </StyledCollapse>
     </StyledCell>
   );

--- a/components/DataDictionary/components/TableCell/components/DetailCell/utils.ts
+++ b/components/DataDictionary/components/TableCell/components/DetailCell/utils.ts
@@ -6,7 +6,7 @@ import { BIO_NETWORK_COUNT } from "./constants";
 
 /**
  * Build bioNetwork string from the given row.
- * @param row - The row.
+ * @param row - Row.
  * @returns The bioNetwork string.
  */
 export function buildBioNetworks(row: Row<Attribute>): string {
@@ -27,7 +27,7 @@ export function buildBioNetworks(row: Row<Attribute>): string {
 
 /**
  * Build example string array from the given attribute.
- * @param attribute - The attribute.
+ * @param attribute - Attribute.
  * @returns The example string array.
  */
 export function buildExample(attribute: Attribute): string[] {
@@ -38,7 +38,7 @@ export function buildExample(attribute: Attribute): string[] {
 /**
  * Build source LinkProps from the given row.
  * Replaces LinkProps with HCA LinkProps for source value "HCA".
- * @param row - The row.
+ * @param row - Row.
  * @returns LinkProps.
  */
 export function buildSource(row: Row<Attribute>): LinkProps {
@@ -48,9 +48,25 @@ export function buildSource(row: Row<Attribute>): LinkProps {
 }
 
 /**
+ * Checks if the annDataLocation column is configured in the table.
+ * @param table - Table.
+ * @returns True if the annDataLocation column is configured, false otherwise.
+ */
+export function shouldShowAnnDataLocationColumn(
+  table: Table<Attribute>
+): boolean {
+  // AnnDataLocation column is configured.
+  const isConfigured = table
+    .getAllColumns()
+    .some((col) => col.id === COLUMN_IDENTIFIERS.ANN_DATA_LOCATION);
+
+  return isConfigured;
+}
+
+/**
  * Checks if the tier column is configured in the table, and tier is present in the annotations.
- * @param table - The table.
- * @param row - The row.
+ * @param table - Table.
+ * @param row - Row.
  * @returns True if the tier column is configured and tier is present in the annotations, false otherwise.
  */
 export function shouldShowTierColumn(

--- a/viewModelBuilders/dataDictionaryMapper/accessorFn.ts
+++ b/viewModelBuilders/dataDictionaryMapper/accessorFn.ts
@@ -5,7 +5,7 @@ import { Attribute } from "./types";
  * @param row - Original row data.
  * @returns Source row value.
  */
-export function buildTier1Source(row: Attribute) {
+export function buildTierNSource(row: Attribute) {
   const { source } = row;
   const { children } = source;
 

--- a/viewModelBuilders/dataDictionaryMapper/columnDefs.ts
+++ b/viewModelBuilders/dataDictionaryMapper/columnDefs.ts
@@ -4,7 +4,7 @@ import { FieldCell } from "../../components/DataDictionary/components/TableCell/
 import { DetailCell } from "../../components/DataDictionary/components/TableCell/components/DetailCell/detailCell";
 import { GridTrackSize } from "@databiosphere/findable-ui/lib/config/entities";
 import { COLUMN_IDENTIFIERS } from "./columnIds";
-import { buildTier1Source } from "./accessorFn";
+import { buildTierNSource } from "./accessorFn";
 
 const ANN_DATA_LOCATION: ColumnDef<Attribute, unknown> = {
   accessorFn: (row) => row.annotations?.annDataLocation,
@@ -162,7 +162,7 @@ export const TIER_1_COLUMN_DEFS: ColumnDef<Attribute, unknown>[] = [
   ANN_DATA_LOCATION,
   {
     ...SOURCE,
-    accessorFn: buildTier1Source,
+    accessorFn: buildTierNSource,
   },
   /* GLOBAL FILTERS */
   LOCATION_NAME,
@@ -178,7 +178,10 @@ export const TIER_2_COLUMN_DEFS: ColumnDef<Attribute, unknown>[] = [
   DETAILS,
   REQUIRED,
   BIO_NETWORK,
-  SOURCE,
+  {
+    ...SOURCE,
+    accessorFn: buildTierNSource,
+  },
   /* GLOBAL FILTERS */
   NAME,
   DESCRIPTION,

--- a/viewModelBuilders/dataDictionaryMapper/columnDefs.ts
+++ b/viewModelBuilders/dataDictionaryMapper/columnDefs.ts
@@ -176,11 +176,12 @@ export const TIER_2_COLUMN_DEFS: ColumnDef<Attribute, unknown>[] = [
   CLASS_KEY,
   FIELD,
   DETAILS,
-  REQUIRED,
+  { ...REQUIRED, enableColumnFilter: false },
   BIO_NETWORK,
   {
     ...SOURCE,
     accessorFn: buildTierNSource,
+    enableColumnFilter: false,
   },
   /* GLOBAL FILTERS */
   NAME,

--- a/viewModelBuilders/dataDictionaryMapper/columnDefs.ts
+++ b/viewModelBuilders/dataDictionaryMapper/columnDefs.ts
@@ -178,7 +178,6 @@ export const TIER_2_COLUMN_DEFS: ColumnDef<Attribute, unknown>[] = [
   DETAILS,
   REQUIRED,
   BIO_NETWORK,
-  TIER,
   SOURCE,
   /* GLOBAL FILTERS */
   NAME,

--- a/viewModelBuilders/dataDictionaryMapper/tableOptions.ts
+++ b/viewModelBuilders/dataDictionaryMapper/tableOptions.ts
@@ -70,7 +70,6 @@ export const TIER_2_TABLE_OPTIONS: Omit<
       rationale: false,
       required: false,
       source: false,
-      tier: false,
       title: false,
       values: false,
     },


### PR DESCRIPTION
Closes #2820.

This pull request introduces updates to the `DataDictionary` components and view model builders, focusing on adding support for the `AnnData Location` column, improving configurability, and renaming a function for consistency. Below is a summary of the most important changes:

### Enhancements to `DetailCell` Component:
* Added logic to conditionally display the `AnnData Location` column in the `DetailCell` component by introducing the `shouldShowAnnDataLocationColumn` utility function and updating the JSX to use it. (`[[1]](diffhunk://#diff-069661689f0ee6c12fb3f5fcf9db40cb7bca4c2dfc90225fd01436a3861db732R16)`, `[[2]](diffhunk://#diff-069661689f0ee6c12fb3f5fcf9db40cb7bca4c2dfc90225fd01436a3861db732R111)`, `[[3]](diffhunk://#diff-069661689f0ee6c12fb3f5fcf9db40cb7bca4c2dfc90225fd01436a3861db732R123)`)

### Utility Function Improvements:
* Introduced the `shouldShowAnnDataLocationColumn` function in `utils.ts` to check if the `AnnData Location` column is configured in a table. (`[components/DataDictionary/components/TableCell/components/DetailCell/utils.tsR50-R69](diffhunk://#diff-cbe692583bc6403a787f3e61e7eb6b3d40cd86c7762b41136f749594016cabe0R50-R69)`)
* Updated JSDoc comments across utility functions for improved clarity and consistency. (`[[1]](diffhunk://#diff-cbe692583bc6403a787f3e61e7eb6b3d40cd86c7762b41136f749594016cabe0L9-R9)`, `[[2]](diffhunk://#diff-cbe692583bc6403a787f3e61e7eb6b3d40cd86c7762b41136f749594016cabe0L30-R30)`, `[[3]](diffhunk://#diff-cbe692583bc6403a787f3e61e7eb6b3d40cd86c7762b41136f749594016cabe0L41-R41)`)

### View Model Builder Updates:
* Renamed `buildTier1Source` to `buildTierNSource` for better alignment with its functionality and updated all references accordingly. (`[[1]](diffhunk://#diff-433bc95182bf578d3c679403f699df25cd144b38914d3cbf2480b972cf35803bL8-R8)`, `[[2]](diffhunk://#diff-10495c94e0d5f47859e7500c12d18908a1478c7fdf0883b03b5535ac0b3a4c1aL7-R7)`, `[[3]](diffhunk://#diff-10495c94e0d5f47859e7500c12d18908a1478c7fdf0883b03b5535ac0b3a4c1aL165-R165)`, `[[4]](diffhunk://#diff-10495c94e0d5f47859e7500c12d18908a1478c7fdf0883b03b5535ac0b3a4c1aL179-R185)`)
* Modified the `TIER_2_COLUMN_DEFS` to disable column filtering for the `REQUIRED` and `SOURCE` columns. (`[viewModelBuilders/dataDictionaryMapper/columnDefs.tsL179-R185](diffhunk://#diff-10495c94e0d5f47859e7500c12d18908a1478c7fdf0883b03b5535ac0b3a4c1aL179-R185)`)

### Configuration Adjustments:
* Removed the `tier` property from the `TIER_2_TABLE_OPTIONS` configuration to simplify table options. (`[viewModelBuilders/dataDictionaryMapper/tableOptions.tsL73](diffhunk://#diff-0b80c4f1540c198908ac22c618a8c0b10348e81871855fb37757cf303c14530bL73)`)