### PR TITLE
feat: cell annotation metadata dictionary is missing cellannotation_metadata from json (#2827)

### DIFF
--- a/site-config/data-portal/dev/dataDictionary/cell-annotation.json
+++ b/site-config/data-portal/dev/dataDictionary/cell-annotation.json
@@ -507,6 +507,41 @@
       "attributes": [
         {
           "annotations": {
+            "annDataLocation": "uns",
+            "bioNetworks": [
+              "adipose",
+              "breast",
+              "development",
+              "eye",
+              "genetic-diversity",
+              "gut",
+              "heart",
+              "immune",
+              "kidney",
+              "liver",
+              "lung",
+              "musculoskeletal",
+              "nervous-system",
+              "oral",
+              "organoid",
+              "pancreas",
+              "reproduction",
+              "skin"
+            ],
+            "cap": "cellannotation_metadata",
+            "tier": "Cell Annotation"
+          },
+          "description": "Python dictionary within the uns dictionary, with the key the string [cellannotation_setname].\n\nThe rest of the dictionary as defined below.",
+          "example": "'{[cellannotation_set]--metadata:{'annotation_method':'algorithmic'...}}'",
+          "multivalued": false,
+          "name": "{cellannotation_set}--metadata",
+          "range": "python dictionary",
+          "required": true,
+          "title": "Cell Annotation Metadata",
+          "values": ""
+        },
+        {
+          "annotations": {
             "annDataLocation": "obs",
             "bioNetworks": [
               "adipose",

--- a/site-config/data-portal/dev/dataDictionary/cell-annotation.json
+++ b/site-config/data-portal/dev/dataDictionary/cell-annotation.json
@@ -537,7 +537,7 @@
           "name": "{cellannotation_set}--metadata",
           "range": "python dictionary",
           "required": true,
-          "title": "Cell Annotation Metadata",
+          "title": "Annotation Set Metadata",
           "values": ""
         },
         {

--- a/site-config/data-portal/dev/dataDictionary/cell-annotation.json
+++ b/site-config/data-portal/dev/dataDictionary/cell-annotation.json
@@ -532,7 +532,7 @@
             "tier": "Cell Annotation"
           },
           "description": "Python dictionary within the uns dictionary, with the key the string [cellannotation_setname].\n\nThe rest of the dictionary as defined below.",
-          "example": "'{[cellannotation_set]--metadata:{'annotation_method':'algorithmic'...}}'",
+          "example": "'{{cellannotation_set}--metadata:{'annotation_method':'algorithmic'...}}'",
           "multivalued": false,
           "name": "{cellannotation_set}--metadata",
           "range": "python dictionary",


### PR DESCRIPTION
Closes #2827.

<img width="1320" height="458" alt="image" src="https://github.com/user-attachments/assets/8908404b-d346-4761-b567-afaa1b1cfa9c" />

This pull request adds a new attribute to the `cell-annotation.json` file in the data dictionary for the data portal. The new attribute provides metadata for cell annotations, including detailed descriptions, examples, and associated biological networks.

### Updates to the data dictionary:

* **New cell annotation metadata attribute**:
  - Added a new attribute named `{cellannotation_set}--metadata` to the `annotation_set` object.
  - Includes metadata such as `annDataLocation`, `bioNetworks`, `cap`, and `tier`.
  - Provides a description, example, and additional details for the `Cell Annotation Metadata`.