### PR TITLE
chore: updated catalog and updates for dcp51 #2831

### DIFF
--- a/docs/dcp-updates.mdx
+++ b/docs/dcp-updates.mdx
@@ -7,6 +7,23 @@ title: HCA Data Portal Updates
 
 # HCA Data Portal Platform Updates
 
+## August 11, 2025
+
+### New projects (7):
+
+1. [Exploring cellular changes in ruptured human quadriceps tendons at single-cell resolution](https://data.humancellatlas.org/explore/projects/8dcbd84a-6243-4501-a684-0dcd084bb536)
+1. [Extracellular matrix remodelling in dental pulp tissue of carious human teeth through the prism of single-cell RNA sequencing](https://data.humancellatlas.org/explore/projects/fed95462-3420-44fb-8b9d-2efbffb35479)
+1. [Extricating human tumour immune alterations from tissue inflammation](https://data.humancellatlas.org/explore/projects/ea9f4ea7-d7b3-41e7-b23a-43f95f569074)
+1. [High-resolution single-cell transcriptomic survey of cardiomyocytes from patients with hypertrophic cardiomyopathy](https://data.humancellatlas.org/explore/projects/b486e0d9-dd8e-462a-b662-9a5bbad5edae)
+1. [Single-cell RNA landscape of the osteoimmunology microenvironment in periodontitis](https://data.humancellatlas.org/explore/projects/40604447-14e4-4e55-ad22-1fd2d7eb4c68)
+1. [Single-cell RNA-seq analysis throughout a 125-day differentiation protocol that converted H1 human embryonic stem cells to a variety of ventrally-derived cell types.](https://data.humancellatlas.org/explore/projects/2043c65a-1cf8-4828-a656-9e247d4e64f1)
+1. [Spatially resolved transcriptomics reveals pro-inflammatory fibroblast involved in lymphocyte recruitment through CXCL8 and CXCL10](https://data.humancellatlas.org/explore/projects/6137c3f4-261f-4192-b32e-4827a77ff793)
+
+### Updated projects (2):
+
+1. [Extreme heterogeneity of influenza virus infection in single cells](https://data.humancellatlas.org/explore/projects/5bb1f67e-2ff0-4848-bbcf-17d133f0fd2d)
+1. [The regulatory landscapes of human ovarian ageing](https://data.humancellatlas.org/explore/projects/0d4aaaac-02c3-44c4-8ae0-4465f97f83ed)
+
 ## June 16, 2025
 
 ### New projects (5):

--- a/site-config/data-portal/dev/config.ts
+++ b/site-config/data-portal/dev/config.ts
@@ -23,7 +23,7 @@ import {
 import { SELECTED_MATCH } from "@databiosphere/findable-ui/lib/components/Layout/components/Header/common/entities";
 
 const APP_TITLE = "HCA Data Portal";
-const CATALOG = "dcp50";
+const CATALOG = "dcp51";
 export const DATA_URL = "https://service.azul.data.humancellatlas.org";
 const EXPLORER_URL = "https://explore.data.humancellatlas.dev.clevercanary.com";
 export const GIT_HUB_REPO_URL = "https://github.com/DataBiosphere/data-portal";


### PR DESCRIPTION
#### Ticket

Closes #2831. 

#### Changes
This pull request updates the HCA Data Portal documentation and configuration to reflect the latest data release and newly available projects. The main changes include adding a new release section to the platform updates and incrementing the catalog version in the development configuration.

**Documentation updates:**

* Added an "August 11, 2025" section to `docs/dcp-updates.mdx` listing 7 new projects and 2 updated projects now available in the portal.

**Configuration updates:**

* Updated the `CATALOG` constant in `site-config/data-portal/dev/config.ts` from `"dcp50"` to `"dcp51"` to point the development environment at the latest data release.