### PR TITLE
chore: updated catalog and updates for dcp53 #2848

### DIFF
--- a/docs/dcp-updates.mdx
+++ b/docs/dcp-updates.mdx
@@ -7,6 +7,20 @@ title: HCA Data Portal Updates
 
 # HCA Data Portal Platform Updates
 
+## October 2, 2025
+
+### New projects (3):
+
+1. [A Unique Cellular Organization of Human Distal Airways and Its Disarray in Chronic Obstructive Pulmonary Disease](https://data.humancellatlas.org/explore/projects/8c4e43fb-f7f3-4446-8367-a3fe9e0b8fd7)
+1. [A cell and transcriptome atlas of human arterial vasculature](https://data.humancellatlas.org/explore/projects/2245bca0-6563-4e88-ab26-f2b8f60383a7)
+1. [Multimodal profiling reveals tissue-directed signatures of human immune cells altered with age](https://data.humancellatlas.org/explore/projects/6179c38c-9987-4e7c-a4bb-d34cf33a3c3f)
+
+### Updated projects (3):
+
+1. [Single-cell RNA-seq reveals heterogeneity within human pre-cDCs](https://data.humancellatlas.org/explore/projects/05be4f37-4506-429b-b112-506444507d62)
+1. [Mapping single-cell transcriptomes in the intra-tumoral and associated territories of kidney cancer.](https://data.humancellatlas.org/explore/projects/8f1f653d-3ea1-4d8e-b4a7-b97dc852c2b1)
+1. [Single-cell analysis reveals fibroblast heterogeneity and myofibroblasts in systemic sclerosis-associated interstitial lung disease](https://data.humancellatlas.org/explore/projects/457d0bfe-79e4-43f1-be5d-83bf080d809e)
+
 ## August 22, 2025
 
 ### New projects (5):

--- a/site-config/data-portal/dev/config.ts
+++ b/site-config/data-portal/dev/config.ts
@@ -23,7 +23,7 @@ import {
 import { SELECTED_MATCH } from "@databiosphere/findable-ui/lib/components/Layout/components/Header/common/entities";
 
 const APP_TITLE = "HCA Data Portal";
-const CATALOG = "dcp52";
+const CATALOG = "dcp53";
 export const DATA_URL = "https://service.azul.data.humancellatlas.org";
 const EXPLORER_URL = "https://explore.data.humancellatlas.dev.clevercanary.com";
 export const GIT_HUB_REPO_URL = "https://github.com/DataBiosphere/data-portal";


### PR DESCRIPTION
#### Ticket

#2848.

#### Changes

This pull request updates the HCA Data Portal with new content and configuration changes. The main changes include adding new and updated project listings to the documentation and updating the catalog version in the development configuration.

Documentation updates:

* Added three new projects and three updated projects to the October 2, 2025 section in `docs/dcp-updates.mdx`.

Configuration changes:

* Updated the `CATALOG` constant from `dcp52` to `dcp53` in `site-config/data-portal/dev/config.ts` to reflect the latest data catalog version.