### PR TITLE
fix: build failing due to large page size requests (#2855)

### DIFF
--- a/constants/networks.ts
+++ b/constants/networks.ts
@@ -79,7 +79,6 @@ export const NETWORKS: Network[] = [
       "tail",
       "umbilical cord",
       "whole embryos",
-      "whole embryos",
     ],
     key: "development",
     name: "Development Network",

--- a/site-config/data-portal/dev/config.ts
+++ b/site-config/data-portal/dev/config.ts
@@ -46,7 +46,7 @@ export function makeConfig(
     browserURL: browserUrl,
     dataSource: {
       defaultListParams: {
-        size: "100",
+        size: "75",
       },
       defaultParams: {
         catalog,


### PR DESCRIPTION
Closes #2855.

Also fixes build errors `HTTPError: Request failed with status code 400 Bad Request` for `/hca-bio-networks/development/datasets` and `/hca-bio-networks/development`.

Request url: https://service.azul.data.humancellatlas.org/index/projects?size=75&catalog=dcp53&filters=%7B%22specimenOrgan%22%3A%7B%22is%22%3A%5B%22blastocyst%22%2C%22embryo%22%2C%22hindgut%22%2C%22hindlimb%22%2C%22tail%22%2C%22umbilical+cord%22%2C%22whole+embryos%22%2C%22whole+embryos%22%5D%7D%7D fails:

```
{
    "Code": "BadRequestError",
    "Message": "('Duplicate values', 'specimenOrgan')"
}
```

This pull request includes minor updates to the development network configuration and data portal settings to improve accuracy and usability.

Configuration updates:

* Removed a duplicate `"whole embryos"` entry from the `development` network's `tissues` array in `constants/networks.ts`.

Data portal usability improvement:

* Changed the default page size from `100` to `75` in the data portal configuration in `site-config/data-portal/dev/config.ts`.