### PR TITLE
chore: update catalog to dcp57 and add release notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ venv
 
 # claude
 .claude/rules*
+.claude/skills/

--- a/docs/dcp-updates.mdx
+++ b/docs/dcp-updates.mdx
@@ -13,7 +13,7 @@ title: HCA Data Portal Updates
 
 1. [Early lymph node T follicular helper cell signalling hub drives influenza vaccine response in an ancestrally diverse cohort](https://data.humancellatlas.org/explore/projects/6e465c30-1109-4c16-9fd5-deca9f9a05eb)
 
-### Updated Projects (1):
+### Updated projects (1):
 
 1. [Asian Immune Diversity Atlas (AIDA): Asian diversity in human immune cells (Thailand cells)](https://data.humancellatlas.org/explore/projects/76bc0e97-8cae-43d4-a647-477a13be47f9)
 
@@ -26,7 +26,7 @@ title: HCA Data Portal Updates
 1. [Single cell atlas of the human retina](https://data.humancellatlas.org/explore/projects/4bcc16b5-7a47-45bb-b9c0-be9d5336df2d)
 1. [Single-cell multiomics of the human retina reveals hierarchical transcription factor collaboration in mediating cell type-specific effects of genetic variants on gene regulation](https://data.humancellatlas.org/explore/projects/2079bb2e-676e-4bbf-8c68-f9c6459edcbb)
 
-### Updated Projects (1):
+### Updated projects (1):
 
 1. [Spatial transcriptomic profiling of human retinoblastoma](https://data.humancellatlas.org/explore/projects/1662accf-0e0c-48c4-9314-5aba063f2220)
 

--- a/docs/dcp-updates.mdx
+++ b/docs/dcp-updates.mdx
@@ -7,6 +7,16 @@ title: HCA Data Portal Updates
 
 # HCA Data Portal Platform Updates
 
+## March 5, 2026
+
+### New projects (1):
+
+1. [Early lymph node T follicular helper cell signalling hub drives influenza vaccine response in an ancestrally diverse cohort](https://data.humancellatlas.org/explore/projects/6e465c30-1109-4c16-9fd5-deca9f9a05eb)
+
+### Updated Projects (1):
+
+1. [Asian Immune Diversity Atlas (AIDA): Asian diversity in human immune cells (Thailand cells)](https://data.humancellatlas.org/explore/projects/76bc0e97-8cae-43d4-a647-477a13be47f9)
+
 ## December 19, 2025
 
 ### New projects (4):

--- a/site-config/data-portal/dev/config.ts
+++ b/site-config/data-portal/dev/config.ts
@@ -23,7 +23,7 @@ import {
 import { SELECTED_MATCH } from "@databiosphere/findable-ui/lib/components/Layout/components/Header/common/entities";
 
 const APP_TITLE = "HCA Data Portal";
-const CATALOG = "dcp56";
+const CATALOG = "dcp57";
 export const DATA_URL = "https://service.azul.data.humancellatlas.org";
 const EXPLORER_URL = "https://explore.data.humancellatlas.dev.clevercanary.com";
 export const GIT_HUB_REPO_URL = "https://github.com/DataBiosphere/data-portal";


### PR DESCRIPTION
## Ticket
Closes #2881

## Summary
- Update default catalog from dcp56 to dcp57
- Add March 5, 2026 release notes with 1 new project and 1 updated project
- Add `.claude/skills/` to gitignore for personal Claude Code skills

## Test plan
- [ ] Verify the catalog version is updated in the config
- [ ] Verify release notes appear correctly on the updates page

🤖 Generated with [Claude Code](https://claude.com/claude-code)