### PR TITLE
chore: update catalog to dcp58 and add release notes

### DIFF
--- a/docs/dcp-updates.mdx
+++ b/docs/dcp-updates.mdx
@@ -7,6 +7,17 @@ title: HCA Data Portal Updates
 
 # HCA Data Portal Platform Updates
 
+## March 31, 2026
+
+### New projects (2):
+
+1. [A multimodal single-cell atlas of the early adolescence brain uncovers gene regulation associated with brain development and disease susceptibility](https://data.humancellatlas.org/explore/projects/984ce0a2-682d-47a3-b80e-1354dfe51ca3)
+1. [Cell atlas from human intestinal immune priming and effector sites during homeostasis](https://data.humancellatlas.org/explore/projects/c8503de8-d02d-4bda-ad06-4c851b37fa97)
+
+### Updated projects (1):
+
+1. [Anomalous Epithelial Variations and Ectopic Inflammatory Response in Chronic Obstructive Pulmonary Disease](https://data.humancellatlas.org/explore/projects/ad04c8e7-9b7d-4cce-b8e9-01e31da10b94)
+
 ## March 5, 2026
 
 ### New projects (1):

--- a/site-config/data-portal/dev/config.ts
+++ b/site-config/data-portal/dev/config.ts
@@ -23,7 +23,7 @@ import {
 import { SELECTED_MATCH } from "@databiosphere/findable-ui/lib/components/Layout/components/Header/common/entities";
 
 const APP_TITLE = "HCA Data Portal";
-const CATALOG = "dcp57";
+const CATALOG = "dcp58";
 export const DATA_URL = "https://service.azul.data.humancellatlas.org";
 const EXPLORER_URL = "https://explore.data.humancellatlas.dev.clevercanary.com";
 export const GIT_HUB_REPO_URL = "https://github.com/DataBiosphere/data-portal";


### PR DESCRIPTION
## Ticket
Closes #2932

## Summary
- Updated catalog version from dcp57 to dcp58 in config
- Added release notes for March 31, 2026 with 2 new projects and 1 updated project

## Test plan
- [ ] Verify catalog version is correctly set to dcp58
- [ ] Verify release notes render correctly on the updates page

🤖 Generated with [Claude Code](https://claude.com/claude-code)