### PR TITLE
refactor: unify source dataset and integrated object download url generation at build time (#2955)

### DIFF
--- a/@types/network.ts
+++ b/@types/network.ts
@@ -213,6 +213,7 @@ export interface TrackerSourceDataset {
   assay: string[];
   baseFileName: string;
   cellCount: number;
+  datasetAsset?: DatasetAsset;
   disease: string[];
   doi: string | null;
   fileId: string;

--- a/components/HCABioNetworks/Network/Atlas/components/Datasets/components/MainColumn/Table/tracker/hook.ts
+++ b/components/HCABioNetworks/Network/Atlas/components/Datasets/components/MainColumn/Table/tracker/hook.ts
@@ -1,22 +1,18 @@
 import { SORT_DIRECTION } from "@databiosphere/findable-ui/lib/config/entities";
 import { Table, useReactTable } from "@tanstack/react-table";
 import type { TrackerSourceDataset } from "../../../../../../../../../../@types/network";
-import { useAtlas } from "../../../../../../../../../../contexts/atlasContext";
 import { CORE_OPTIONS } from "../../../../../../../../../common/Table/options/core/constants";
 import { SORTING_OPTIONS } from "../../../../../../../../../common/Table/options/sorting/constants";
 import { COLUMNS } from "./columns";
 
 /**
  * Returns a configured TanStack table instance for tracker source datasets.
- * Passes tracker config via table meta for download URL construction.
  * @param data - Tracker source datasets.
  * @returns table instance.
  */
 export const useTable = (
   data: TrackerSourceDataset[]
 ): Table<TrackerSourceDataset> => {
-  const { atlas, network } = useAtlas();
-  const { tracker } = atlas;
   return useReactTable<TrackerSourceDataset>({
     columns: COLUMNS,
     data,
@@ -27,11 +23,6 @@ export const useTable = (
     getRowId: (row) => row.id,
     initialState: {
       sorting: [{ desc: SORT_DIRECTION.ASCENDING, id: "title" }],
-    },
-    meta: {
-      networkKey: network.key,
-      shortNameSlug: tracker?.shortNameSlug,
-      version: tracker?.version,
     },
     state: {
       columnVisibility: {},

--- a/components/HCABioNetworks/Network/Atlas/components/Datasets/components/MainColumn/Table/tracker/viewBuilder.ts
+++ b/components/HCABioNetworks/Network/Atlas/components/Datasets/components/MainColumn/Table/tracker/viewBuilder.ts
@@ -2,44 +2,7 @@ import type { CellContext } from "@tanstack/react-table";
 import type { JSX } from "react";
 import * as C from "../../../../../../../../..";
 import type { TrackerSourceDataset } from "../../../../../../../../../../@types/network";
-import {
-  buildTrackerSourceDatasetAsset,
-  splitFileName,
-} from "../../../../../../../../../../utils/trackerNetwork";
-
-/**
- * Returns the download info for a tracker source dataset.
- * @param sourceDataset - Tracker source dataset.
- * @param networkKey - Network key (e.g., "gut").
- * @param shortNameSlug - Atlas short name slug.
- * @param version - Atlas version.
- * @returns file name (without extension), file size, format, and download URL.
- */
-function getDownloadInfo(
-  sourceDataset: TrackerSourceDataset,
-  networkKey: string,
-  shortNameSlug: string,
-  version: string
-): {
-  downloadUrl: string;
-  fileName: string;
-  fileSize: number;
-  format: string;
-} {
-  const asset = buildTrackerSourceDatasetAsset(
-    sourceDataset,
-    networkKey,
-    shortNameSlug,
-    version
-  );
-  const { ext, stem } = splitFileName(sourceDataset.baseFileName);
-  return {
-    downloadUrl: asset.downloadURL,
-    fileName: `${stem}-r${sourceDataset.revision}`,
-    fileSize: sourceDataset.sizeBytes,
-    format: ext,
-  };
-}
+import { splitFileName } from "../../../../../../../../../../utils/trackerNetwork";
 
 /**
  * Renders the cell count as a locale-formatted string.
@@ -54,29 +17,20 @@ export function renderCellCount(
 
 /**
  * Renders a tracker download cell for a source dataset.
- * Reads tracker config from table meta to build the S3 download URL.
+ * Uses the pre-built datasetAsset from static props.
  * @param ctx - Cell context.
- * @returns TrackerDownloadCell component, or null if tracker config unavailable.
+ * @returns TrackerDownloadCell component, or null if asset unavailable.
  */
 export function renderDownload(
   ctx: CellContext<TrackerSourceDataset, unknown>
 ): JSX.Element | null {
-  const meta = ctx.table.options.meta as {
-    networkKey?: string;
-    shortNameSlug?: string;
-    version?: string;
-  };
-  if (!meta.networkKey || !meta.shortNameSlug || !meta.version) return null;
-  const { downloadUrl, fileName, fileSize, format } = getDownloadInfo(
-    ctx.row.original,
-    meta.networkKey,
-    meta.shortNameSlug,
-    meta.version
-  );
+  const { baseFileName, datasetAsset, revision } = ctx.row.original;
+  if (!datasetAsset) return null;
+  const { ext: format, stem } = splitFileName(baseFileName);
   return C.TrackerDownloadCell({
-    downloadUrl,
-    fileName,
-    fileSize,
+    downloadUrl: datasetAsset.downloadURL,
+    fileName: `${stem}-r${revision}`,
+    fileSize: datasetAsset.fileSize,
     format,
   });
 }

--- a/utils/trackerAtlasPages.ts
+++ b/utils/trackerAtlasPages.ts
@@ -7,7 +7,10 @@ import {
   resolveTrackerAtlasId,
 } from "../apis/tracker/api";
 import type { StaticProps } from "./atlasPages";
-import { mapTrackerComponentAtlasToIntegratedAtlas } from "./trackerNetwork";
+import {
+  buildTrackerSourceDatasetAsset,
+  mapTrackerComponentAtlasToIntegratedAtlas,
+} from "./trackerNetwork";
 
 /**
  * Fetches and builds static props for a tracker-sourced atlas.
@@ -49,6 +52,16 @@ export async function getTrackerContentStaticProps(
     )
   );
 
+  const trackerSourceDatasets = sourceDatasets.map((sd) => ({
+    ...sd,
+    datasetAsset: buildTrackerSourceDatasetAsset(
+      sd,
+      networkKey,
+      shortNameSlug,
+      version
+    ),
+  }));
+
   const processedAtlas: Atlas = {
     ...atlas,
     integratedAtlases,
@@ -68,7 +81,7 @@ export async function getTrackerContentStaticProps(
       network: processedNetwork,
       pageTitle: `${atlas.name} - ${tabName}`,
       projectsResponses: [],
-      trackerSourceDatasets: sourceDatasets,
+      trackerSourceDatasets,
       trackerSourceStudies: sourceStudies,
     },
   };


### PR DESCRIPTION
Closes #2955.

## Summary
- Moved source dataset download URL generation from runtime to build time, matching the integrated object pattern
- Pre-compute `datasetAsset` via `buildTrackerSourceDatasetAsset()` in `trackerAtlasPages.ts` during static generation
- Simplified `renderDownload()` in viewBuilder to read the pre-built asset from row data
- Removed tracker meta (`networkKey`, `shortNameSlug`, `version`) from table hook and `useAtlas()` dependency

Closes #2955

## Test plan
- [x] TypeScript compiles cleanly
- [x] Lint passes
- [x] Dev build succeeds
- [x] Verify source dataset download links work on tracker atlas pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)