### PR TITLE
fix: make cell_type_ontology_term_id optional in tier 1 dictionary (#2977)

### DIFF
--- a/site-config/data-portal/dev/dataDictionary/tier-1.json
+++ b/site-config/data-portal/dev/dataDictionary/tier-1.json
@@ -1637,7 +1637,7 @@
           "name": "cell_type_ontology_term_id",
           "range": "string",
           "rationale": "Encoding of cell type to help alignment with other datasets.",
-          "required": true,
+          "required": false,
           "title": "Cell Type Ontology Term ID",
           "values": "This must be a Cell Ontology (CL) term (http://www.ebi.ac.uk/ols4/ontologies/cl).\n\n If no appropriate high-level term can be found or the cell type is unknown, then it is strongly recommended to use 'unknown'.\n\n The following terms must not be used: \"CL:0000255\" for eukaryotic cell; \"CL:0000257\" for Eumycetozoan cell; \"CL:0000548\" for animal cell."
         }


### PR DESCRIPTION
## Summary
- Changed `cell_type_ontology_term_id` from `"required": true` to `"required": false` in the Tier 1 metadata dictionary

Closes #2977

## Test plan
- [x] Verify the field no longer shows the red "Required" badge in the Tier 1 dictionary UI
- [x] Verify the field appears under the "Recommended" filter category

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="2405" height="1266" alt="image" src="https://github.com/user-attachments/assets/b8f0b311-0dde-4924-a318-2c2a9493eacb" />
