### PR TITLE
fix: move ambient_count_correction and doublet_detection from uns to obs (#2988)

### DIFF
--- a/site-config/data-portal/dev/dataDictionary/tier-1.json
+++ b/site-config/data-portal/dev/dataDictionary/tier-1.json
@@ -457,7 +457,7 @@
         },
         {
           "annotations": {
-            "annDataLocation": "uns",
+            "annDataLocation": "obs",
             "bioNetworks": ["gut"],
             "tier": "Tier 1"
           },
@@ -471,7 +471,7 @@
         },
         {
           "annotations": {
-            "annDataLocation": "uns",
+            "annDataLocation": "obs",
             "bioNetworks": ["gut"],
             "tier": "Tier 1"
           },


### PR DESCRIPTION
## Summary
- Changed `annDataLocation` from `uns` to `obs` for `ambient_count_correction` and `doublet_detection` in Tier 1 dictionary
- Enables integrated atlas files to faithfully record per-library processing metadata

Closes #2988

## Test plan
- [x] Verify both fields show `obs.ambient_count_correction` and `obs.doublet_detection` in the Tier 1 dictionary UI
- [x] Verify AnnData location filter reflects the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="2414" height="678" alt="image" src="https://github.com/user-attachments/assets/ace17b6a-04c1-4307-9e7d-350b9412c4e2" />

<img width="2412" height="731" alt="image" src="https://github.com/user-attachments/assets/ebf58047-0230-47f1-b990-ab7eaebd3622" />

<img width="1480" height="529" alt="image" src="https://github.com/user-attachments/assets/4d0cecab-a066-47c4-876c-e5e74e285497" />

