### PR TITLE
fix: update feature_is_filtered description to current cellxgene schema text (#2989)

### DIFF
--- a/site-config/data-portal/dev/dataDictionary/tier-1.json
+++ b/site-config/data-portal/dev/dataDictionary/tier-1.json
@@ -1709,7 +1709,7 @@
             "cxg": "feature_is_filtered",
             "tier": "Tier 1"
           },
-          "description": "This MUST be `True` if the feature was filtered out in the normalized matrix (`X`) but is present in the raw matrix (`raw.X`). The value for all cells of the given feature in the normalized matrix MUST be `0`.\n\nOtherwise, this MUST be `False`.",
+          "description": "When both a raw and normalized matrix are present, this MUST be `True` if the feature was filtered out in the normalized matrix (`X`) but is present in the raw matrix (`raw.X`). The value for all cells of the given feature in the normalized matrix MUST be `0`. If a feature contains all zeroes in the normalized matrix, then either the corresponding feature in the raw matrix MUST be all zeroes or the value MUST be `True`.",
           "example": "",
           "multivalued": false,
           "name": "feature_is_filtered",


### PR DESCRIPTION
## Summary
- Updated `feature_is_filtered` description in Tier 1 dictionary to match current CELLxGENE schema
- Removes the overly strict "Otherwise, this MUST be `False`" clause
- Adds the correct wording: all-zero features in the normalized matrix may have `True` or `False` if the raw matrix is also all-zero

## Drift audit

Checked all CXG-annotated fields in tier-1.json against CELLxGENE schema v5.3.0. No other fields have restrictive drift — descriptions are simplified summaries that don't contradict or over-constrain the schema:

| Field | Drift? |
|---|---|
| `assay_ontology_term_id` | No — simplified summary |
| `donor_id` | No — matches schema |
| `organism_ontology_term_id` | No — simplified |
| `sex_ontology_term_id` | No — simplified |
| `tissue_ontology_term_id` | No — matches schema intent |
| `tissue_type` | No — matches schema |
| `disease_ontology_term_id` | No — simplified |
| `suspension_type` | No — simplified |
| `development_stage_ontology_term_id` | No — simplified |
| `feature_is_filtered` | **Fixed in this PR** |
| `feature_biotype`, `feature_name`, `feature_reference` | No — match schema |

Closes #2989

## Test plan
- [x] Verify updated description renders correctly in the Tier 1 dictionary UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="2452" height="1014" alt="image" src="https://github.com/user-attachments/assets/9bf2f612-9b6e-4928-b85d-f1c37dbdd7ce" />
