### PR TITLE
fix: remove self_reported_ethnicity_ontology_term_id from tier 1 dictionary (#3006)

### DIFF
--- a/docs/contribute/submitting-hca-data-to-cellxgene-discover.mdx
+++ b/docs/contribute/submitting-hca-data-to-cellxgene-discover.mdx
@@ -64,10 +64,9 @@ An AnnData file has several components, including:
 
 </StyledTable>
 
-In addition to the HCA obs fields above, there are an additional three fields that are required for submission into CELLxGENE. These fields are not part of the HCA Tier 1 metadata fields.
+In addition to the HCA obs fields above, there are an additional two fields that are required for submission into CELLxGENE. These fields are not part of the HCA Tier 1 metadata fields.
     - [disease_ontology_term_id](https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/4.0.0/schema.md#disease_ontology_term_id)
     - [development_stage_ontology_term_id](https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/4.0.0/schema.md#development_stage_ontology_term_id)
-    - [self_reported_ethnicity_ontology_term_id](https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/4.0.0/schema.md#self_reported_ethnicity_ontology_term_id)
 
 - **Embeddings in obsm:**
     - One or more two-dimensional embeddings, prefixed with 'X_'

--- a/site-config/data-portal/dev/dataDictionary/tier-1.json
+++ b/site-config/data-portal/dev/dataDictionary/tier-1.json
@@ -667,41 +667,6 @@
           "required": true,
           "title": "Sex Ontology Term ID",
           "values": "This must be a child of PATO:0001894 for phenotypic sex or \"unknown\" if unavailable."
-        },
-        {
-          "annotations": {
-            "annDataLocation": "obs",
-            "bioNetworks": [
-              "adipose",
-              "breast",
-              "development",
-              "eye",
-              "genetic-diversity",
-              "gut",
-              "heart",
-              "immune",
-              "kidney",
-              "liver",
-              "lung",
-              "musculoskeletal",
-              "nervous-system",
-              "oral-and-craniofacial",
-              "organoid",
-              "pancreas",
-              "reproduction",
-              "skin"
-            ],
-            "tier": "Tier 1"
-          },
-          "description": "Self reported ethnicity of the subject.",
-          "example": "unknown; HANCESTRO:0008",
-          "multivalued": true,
-          "name": "self_reported_ethnicity_ontology_term_id",
-          "range": "string",
-          "rationale": "CELLxGENE core schema",
-          "required": true,
-          "title": "Self Reported Ethnicity Ontology Term ID",
-          "values": "If organism_ontolology_term_id is \"NCBITaxon:9606\" for *Homo sapiens*, this must be a HANCESTRO term or \"unknown\". Otherwise, for all organisms, this must be \"na\".\n\n**Requirements for data contributors adhering to GDPR or like standards**: HCA will be collecting ethnicity data as part of HCA's Tier 2 metadata that is protected by managed access, therefore please put 'unknown' for this field."
         }
       ]
     },


### PR DESCRIPTION
## Summary
- Removed `self_reported_ethnicity_ontology_term_id` entry from Tier 1 dictionary (`tier-1.json`)
- Updated docs (`submitting-hca-data-to-cellxgene-discover.mdx`) to remove the reference and adjust "three fields" to "two fields"
- Ethnicity data is collected as part of Tier 2 under managed access, so it should not be in Tier 1

Closes #3006

## Test plan
- [ ] Verify `self_reported_ethnicity_ontology_term_id` no longer appears in the Tier 1 dictionary UI
- [ ] Verify the CELLxGENE submission docs page renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="2315" height="745" alt="image" src="https://github.com/user-attachments/assets/90c3a7aa-7326-40b0-a2be-4b7c6c91d3bc" />

<img width="2316" height="1199" alt="image" src="https://github.com/user-attachments/assets/77a82e80-df7c-4ce2-926b-04dd8cc5b757" />
