### PR TITLE
fix: change source of development_stage_ontology_term_id from cellxgene to hca (#3007)

### DIFF
--- a/docs/contribute/submitting-hca-data-to-cellxgene-discover.mdx
+++ b/docs/contribute/submitting-hca-data-to-cellxgene-discover.mdx
@@ -64,9 +64,8 @@ An AnnData file has several components, including:
 
 </StyledTable>
 
-In addition to the HCA obs fields above, there are an additional two fields that are required for submission into CELLxGENE. These fields are not part of the HCA Tier 1 metadata fields.
-    - [disease_ontology_term_id](https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/4.0.0/schema.md#disease_ontology_term_id)
-    - [development_stage_ontology_term_id](https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/4.0.0/schema.md#development_stage_ontology_term_id)
+In addition to the HCA obs fields above, there are additional fields that are required for submission into CELLxGENE. These fields are not part of the HCA Tier 1 metadata fields.
+- [disease_ontology_term_id](https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/4.0.0/schema.md#disease_ontology_term_id)
 
 - **Embeddings in obsm:**
     - One or more two-dimensional embeddings, prefixed with 'X_'

--- a/docs/contribute/submitting-hca-data-to-cellxgene-discover.mdx
+++ b/docs/contribute/submitting-hca-data-to-cellxgene-discover.mdx
@@ -64,7 +64,7 @@ An AnnData file has several components, including:
 
 </StyledTable>
 
-In addition to the HCA obs fields above, there are additional fields that are required for submission into CELLxGENE. These fields are not part of the HCA Tier 1 metadata fields.
+In addition to the HCA obs fields above, below are additional fields that are required for submission into CELLxGENE. These fields are not part of the HCA Tier 1 metadata fields.
 - [disease_ontology_term_id](https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/4.0.0/schema.md#disease_ontology_term_id)
 
 - **Embeddings in obsm:**

--- a/docs/contribute/submitting-hca-data-to-cellxgene-discover.mdx
+++ b/docs/contribute/submitting-hca-data-to-cellxgene-discover.mdx
@@ -64,8 +64,9 @@ An AnnData file has several components, including:
 
 </StyledTable>
 
-In addition to the HCA obs fields above, below are additional fields that are required for submission into CELLxGENE. These fields are not part of the HCA Tier 1 metadata fields.
+In addition to the HCA obs fields above, there are an additional two fields that are required for submission into CELLxGENE. These fields are not part of the HCA Tier 1 metadata fields.
 - [disease_ontology_term_id](https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/4.0.0/schema.md#disease_ontology_term_id)
+- [development_stage_ontology_term_id](https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/4.0.0/schema.md#development_stage_ontology_term_id)
 
 - **Embeddings in obsm:**
     - One or more two-dimensional embeddings, prefixed with 'X_'

--- a/site-config/data-portal/dev/dataDictionary/tier-1.json
+++ b/site-config/data-portal/dev/dataDictionary/tier-1.json
@@ -1085,7 +1085,6 @@
               "reproduction",
               "skin"
             ],
-            "cxg": "development_stage_ontology_term_id",
             "tier": "Tier 1"
           },
           "description": "Age of the subject.",
@@ -1093,7 +1092,7 @@
           "multivalued": false,
           "name": "development_stage_ontology_term_id",
           "range": "string",
-          "rationale": "CELLxGENE core schema",
+          "rationale": "Developmental stage is a key biological covariate for interpreting cell state and comparing samples across donors.",
           "required": true,
           "title": "Development Stage Ontology Term ID",
           "values": "If organism_ontolology_term_id is \"NCBITaxon:9606\" for *Homo sapiens*, this should be an HsapDv term. If organism_ontolology_term_id is \"NCBITaxon:10090\" for *Mus musculus*, this should be an HsapDv term.\n\n**Requirements for data contributors adhering to GDPR or like standards**: HCA requests that you do not submit year-specific terms. For convenience, below are some broader age bracket ontology terms:\n* Embryonic stage = A term from the set of Carnegie stages 1-23 = (up to 8 weeks after conception; e.g. HsapDv:0000003)\n* Fetal development = A term from the set of 9 to 38 week post-fertilization human stages = (9 weeks after conception and before birth; e.g. HsapDv:0000046)\n* Post natal =\n  * Years 0-14 HsapDv:0000264\n  * Years 15-19 HsapDv:0000268\n  * Years 20-29 HsapDv:0000237\n  * Years 30-39 HsapDv:0000238\n  * Years 40-49 HsapDv:0000239\n  * Years 50-59 HsapDv:0000240\n  * Years 60-69 HsapDv:0000241\n  * Years 70-79 HsapDv:0000242\n  * Years 80-89 HsapDv:0000243"


### PR DESCRIPTION
## Summary
- Removed `cxg` annotation from `development_stage_ontology_term_id` in Tier 1 dictionary, re-attributing it to HCA
- Replaced rationale "CELLxGENE core schema" with "Developmental stage is a key biological covariate for interpreting cell state and comparing samples across donors."
- Updated CELLxGENE submission docs to remove `development_stage_ontology_term_id` from the list of CELLxGENE-only fields

Closes #3007

## Test plan
- [x] Verify `development_stage_ontology_term_id` no longer shows CELLxGENE as its source in the Tier 1 dictionary UI
- [x] Verify the CELLxGENE submission docs page renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="2314" height="1280" alt="image" src="https://github.com/user-attachments/assets/6d335000-4b2d-452f-9407-8c623329d1a9" />
