### PR TITLE
fix: update retina cell atlas link to published nature genetics paper (#3039)

### DIFF
--- a/constants/networks.ts
+++ b/constants/networks.ts
@@ -104,8 +104,8 @@ export const NETWORKS: Network[] = [
         path: RETINA_V1_0,
         publications: [
           {
-            doi: "https://doi.org/10.1101/2023.11.07.566105",
-            label: "Li et al. (2023) bioRxiv",
+            doi: "https://doi.org/10.1038/s41588-025-02454-1",
+            label: "Li et al. (2026) Nat Genet",
           },
         ],
         summaryCellCount: 3548094,


### PR DESCRIPTION
## Summary

- Updates the Retina cell atlas v1.0 publication entry in `constants/networks.ts` to point at the peer-reviewed Nature Genetics paper (published 23 January 2026) instead of the 2023 bioRxiv preprint
- DOI swapped to `10.1038/s41588-025-02454-1`; label updated to `"Li et al. (2026) Nat Genet"` to match the existing convention in the file

Closes #3039.

## Test plan

- [x] Verify the Retina cell atlas page (`/hca-bio-networks/eye/atlases/retina-v1-0`) renders the updated citation linking to the Nature Genetics article
- [x] Confirm the link resolves to the published article, not the preprint

<img width="2482" height="1000" alt="image" src="https://github.com/user-attachments/assets/5e36b2f6-6a1f-41b6-8dae-8d30ba97f1d9" />
