### PR TITLE
feat: add "recommended" tag to metadata dictionary fields (#3062)

### DIFF
--- a/components/DataDictionary/components/TableCell/components/FieldCell/fieldCell.tsx
+++ b/components/DataDictionary/components/TableCell/components/FieldCell/fieldCell.tsx
@@ -69,7 +69,7 @@ export const FieldCell = ({
           />
         ))}
         {/* REQUIRED */}
-        {row.original.required && <Chip {...buildRequired(row)} />}
+        <Chip {...buildRequired(row)} />
       </StyledStack>
       {/* RANGE */}
       <StyledTypography>{buildRange(row.original)}</StyledTypography>

--- a/components/DataDictionary/components/TableCell/components/FieldCell/utils.ts
+++ b/components/DataDictionary/components/TableCell/components/FieldCell/utils.ts
@@ -30,7 +30,6 @@ export function buildRange(attribute: Attribute): string {
 
 /**
  * Builds ChipCell props from the given attribute, for required.
- * Only called when required is truthy (true or "strongly recommended").
  * @param row - Row.
  * @returns Model to be used as props for the Chip component.
  */


### PR DESCRIPTION
## Summary

Closes #3062.

Show the existing grey "Recommended" chip on data dictionary rows that map to `RequirementLabel.RECOMMENDED`, consistent with the existing Required (red) and Strongly Recommended (orange) tags.

The accessor `buildRequired` in `viewModelBuilders/dataDictionaryMapper/accessorFn.ts` was already returning `RequirementLabel.RECOMMENDED` for non-required / non-strongly-recommended rows, and `REQUIREMENT_LABEL_COLOR[RECOMMENDED]` was already mapped to `CHIP_PROPS.COLOR.DEFAULT` (grey). Only the `row.original.required &&` guard at `fieldCell.tsx:72` was blocking the chip render — removed.

- `components/DataDictionary/components/TableCell/components/FieldCell/fieldCell.tsx` — drop the conditional, render the chip unconditionally.
- `components/DataDictionary/components/TableCell/components/FieldCell/utils.ts` — strip the now-stale "Only called when required is truthy" line from `buildRequired`'s JSDoc.

## Test plan

- [x] Navigate to any metadata dictionary page. Confirm fields that previously had no chip now show a grey "Recommended" chip.
- [x] Confirm Required (red) and Strongly Recommended (orange) chips still render as before.
- [x] Visual: grey chip matches the colour weight of the existing red/orange chips (same `variant=STATUS`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="2022" height="1254" alt="image" src="https://github.com/user-attachments/assets/7a240e78-911d-4a82-bd75-e427c7134514" />
