### PR TITLE
feat: gut v1.0 atlas cleanup: source studies / source datasets table columns + filters (#3074)

### DIFF
--- a/@types/network.ts
+++ b/@types/network.ts
@@ -220,8 +220,11 @@ export interface TrackerSourceDataset {
   fileName: string;
   geneCount: number;
   id: string;
+  publicationString: string | null;
   revision: number;
   sizeBytes: number;
+  sourceStudyId: string;
+  sourceStudyTitle: string;
   tissue: string[];
   title: string;
 }

--- a/components/HCABioNetworks/Network/Atlas/components/Datasets/components/MainColumn/tracker/components/table/columns.ts
+++ b/components/HCABioNetworks/Network/Atlas/components/Datasets/components/MainColumn/tracker/components/table/columns.ts
@@ -10,7 +10,22 @@ import {
   buildPinnedNTagProps,
   renderPinnedNTagCell,
 } from "../../../../../../../../../../common/Table/components/Cell/components/PinnedNTagCell/utils";
-import { renderCellCount, renderDownload } from "./viewBuilder";
+import {
+  renderCellCount,
+  renderDownload,
+  renderSourceStudy,
+} from "./viewBuilder";
+
+const ASSAY = {
+  accessorKey: "assay",
+  cell: renderNTagCell(buildNTagProps("assays", "assay")),
+  enableColumnFilter: true,
+  filterFn: "arrIncludesSome",
+  header: "Assay",
+  id: "assay",
+  meta: { width: { max: "1fr", min: "100px" } },
+  sortingFn,
+} as ColumnDef<TrackerSourceDataset>;
 
 const CELL_COUNT = {
   accessorKey: "cellCount",
@@ -45,6 +60,17 @@ const DOWNLOAD = {
   meta: { width: "auto" },
 } as ColumnDef<TrackerSourceDataset>;
 
+const SOURCE_STUDY = {
+  accessorKey: "publicationString",
+  cell: renderSourceStudy,
+  enableColumnFilter: true,
+  filterFn: "arrIncludesSome",
+  header: "Source Study",
+  id: "sourceStudy",
+  meta: { width: { max: "1.2fr", min: "200px" } },
+  sortingFn,
+} as ColumnDef<TrackerSourceDataset>;
+
 const TISSUE = {
   accessorKey: "tissue",
   cell: renderNTagCell(buildNTagProps("tissues", "tissue")),
@@ -67,6 +93,8 @@ const TITLE = {
 
 export const COLUMNS: ColumnDef<TrackerSourceDataset>[] = [
   TITLE,
+  SOURCE_STUDY,
+  ASSAY,
   TISSUE,
   DISEASE,
   CELL_COUNT,

--- a/components/HCABioNetworks/Network/Atlas/components/Datasets/components/MainColumn/tracker/components/table/viewBuilder.ts
+++ b/components/HCABioNetworks/Network/Atlas/components/Datasets/components/MainColumn/tracker/components/table/viewBuilder.ts
@@ -1,8 +1,14 @@
+import {
+  ANCHOR_TARGET,
+  REL_ATTRIBUTE,
+} from "@databiosphere/findable-ui/lib/components/Links/common/entities";
 import type { CellContext } from "@tanstack/react-table";
 import type { JSX } from "react";
 import * as C from "../../../../../../../../../..";
 import type { TrackerSourceDataset } from "../../../../../../../../../../../@types/network";
 import { splitFileName } from "../../../../../../../../../../../utils/trackerNetwork";
+
+const DOI_BASE_URL = "https://doi.org/";
 
 /**
  * Renders the cell count as a locale-formatted string.
@@ -32,5 +38,24 @@ export function renderDownload(
     fileName: `${stem}-r${revision}`,
     fileSize: datasetAsset.fileSize,
     format,
+  });
+}
+
+/**
+ * Renders the source study shorthand citation as a link to the DOI.
+ * @param ctx - Cell context with publicationString from accessorKey.
+ * @returns Link component, or null if no citation.
+ */
+export function renderSourceStudy(
+  ctx: CellContext<TrackerSourceDataset, string | null>
+): JSX.Element | null {
+  const label = ctx.getValue();
+  if (!label) return null;
+  const { doi } = ctx.row.original;
+  return C.Link({
+    label,
+    rel: REL_ATTRIBUTE.NO_OPENER_NO_REFERRER,
+    target: ANCHOR_TARGET.BLANK,
+    url: doi ? `${DOI_BASE_URL}${doi}` : "",
   });
 }

--- a/components/HCABioNetworks/Network/Atlas/components/SourceStudies/components/MainColumn/tracker/components/table/columns.ts
+++ b/components/HCABioNetworks/Network/Atlas/components/SourceStudies/components/MainColumn/tracker/components/table/columns.ts
@@ -30,15 +30,6 @@ const REFERENCE_AUTHOR = {
   id: "referenceAuthor",
 } as ColumnDef<TrackerSourceStudy>;
 
-const SOURCE_DATASET_COUNT = {
-  accessorKey: "sourceDatasetCount",
-  enableColumnFilter: false,
-  header: "Datasets",
-  id: "sourceDatasetCount",
-  meta: { width: { max: "0.5fr", min: "140px" } },
-  sortingFn: "basic",
-} as ColumnDef<TrackerSourceStudy>;
-
 const SOURCE_STUDY = {
   accessorFn: buildSourceStudy,
   cell: renderSourceStudy,
@@ -61,7 +52,6 @@ const TITLE = {
 export const COLUMNS: ColumnDef<TrackerSourceStudy>[] = [
   SOURCE_STUDY,
   TITLE,
-  SOURCE_DATASET_COUNT,
   HCA_DATA_REPOSITORY,
   JOURNAL,
   REFERENCE_AUTHOR,


### PR DESCRIPTION
## Summary
- Removes the **Datasets** column from the Source Studies table (`sourceDatasetCount` linking still being reviewed by the Gut team).
- Adds a **Source Study** column to the Source Datasets table, rendered as a shorthand citation link to the study DOI (uses the existing `publicationString` from the API response).
- Adds an **Assay** column to the Source Datasets table as an NTag cell.
- Adds filters for **Source Study** and **Assay**; filter bar order follows column order → Source Study → Assay → Tissue → Disease.
- Extends `TrackerSourceDataset` with `publicationString`, `sourceStudyId`, `sourceStudyTitle` (already in the API response, missing from the hand-written type).

Closes #3074

## Test plan
- [x] Visit `/hca-bio-networks/gut/atlases/gut-v1-0/source-studies` and confirm the Datasets column is gone.
- [x] Visit `/hca-bio-networks/gut/atlases/gut-v1-0/datasets` and confirm column order: Dataset → Source Study → Assay → Tissue → Disease → Cell Count → Download.
- [x] Confirm the Source Study cell shows the shorthand citation (e.g. `Boland (2020) Science Immunology`) and links out to the DOI in a new tab.
- [x] Confirm the Assay cell renders as an NTag cell consistent with Tissue/Disease.
- [x] Confirm the filter bar shows Source Study → Assay → Tissue → Disease and each filter applies correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="2543" height="1164" alt="image" src="https://github.com/user-attachments/assets/6f060651-920f-45fd-a19a-dc07afc703eb" />

<img width="2548" height="1115" alt="image" src="https://github.com/user-attachments/assets/0281a0b7-ddd9-48c6-83f1-1ef707ed559d" />
