### PR TITLE
feat: rename non-tracker tab to source studies + tab definitions (#3076)

### DIFF
--- a/components/HCABioNetworks/Network/Atlas/components/Datasets/components/MainColumn/mainColumn.tsx
+++ b/components/HCABioNetworks/Network/Atlas/components/Datasets/components/MainColumn/mainColumn.tsx
@@ -1,7 +1,7 @@
 import { FluidPaper } from "@databiosphere/findable-ui/lib/components/common/Paper/paper.styles";
 import { BackPageContentSingleColumn } from "@databiosphere/findable-ui/lib/components/Layout/components/BackPage/backPageView.styles";
 import { JSX } from "react";
-import { AtlasDatasetsDescription } from "../../../../../../../../content";
+import { SourceStudiesDescription } from "../../../../../../../../content";
 import { useAtlas } from "../../../../../../../../contexts/atlasContext";
 import { useSiteConfig } from "../../../../../../../../hooks/useSiteConfig";
 import { getProjectsTableColumns } from "../../../../../../../../viewModelBuilders/viewModelBuilders";
@@ -16,25 +16,25 @@ export const MainColumn = (): JSX.Element => {
   const isTracker = Boolean(atlas.tracker);
   return (
     <BackPageContentSingleColumn>
-      {/* Atlas Datasets Description */}
-      <FluidPaper>
-        <MDXSection>
-          <AtlasDatasetsDescription />
-        </MDXSection>
-      </FluidPaper>
-      {/* Atlas Datasets */}
       {isTracker ? (
         <SourceDatasets data={trackerSourceDatasets} />
       ) : (
-        <DetailViewTable
-          columns={getProjectsTableColumns(browserURL)}
-          gridTemplateColumns="minmax(484px, 1fr) repeat(4, minmax(152px, 1fr)) max-content"
-          items={projectsResponses}
-          noResultsTitle={"No Source Datasets"}
-          Paper={FluidPaper}
-          tableOptions={TABLE_OPTIONS}
-          tools={null}
-        />
+        <>
+          <FluidPaper>
+            <MDXSection>
+              <SourceStudiesDescription />
+            </MDXSection>
+          </FluidPaper>
+          <DetailViewTable
+            columns={getProjectsTableColumns(browserURL)}
+            gridTemplateColumns="minmax(484px, 1fr) repeat(4, minmax(152px, 1fr)) max-content"
+            items={projectsResponses}
+            noResultsTitle={"No Source Studies"}
+            Paper={FluidPaper}
+            tableOptions={TABLE_OPTIONS}
+            tools={null}
+          />
+        </>
       )}
     </BackPageContentSingleColumn>
   );

--- a/components/HCABioNetworks/Network/Atlas/components/Datasets/components/MainColumn/tracker/sourceDatasets.tsx
+++ b/components/HCABioNetworks/Network/Atlas/components/Datasets/components/MainColumn/tracker/sourceDatasets.tsx
@@ -1,8 +1,10 @@
 import { FluidPaper } from "@databiosphere/findable-ui/lib/components/common/Paper/components/FluidPaper/fluidPaper";
 import { GridPaper } from "@databiosphere/findable-ui/lib/components/common/Paper/paper.styles";
 import { JSX } from "react";
+import { SourceDatasetsDescription } from "../../../../../../../../../content";
 import { ColumnFilters } from "../../../../../../../../common/Filters/components/ColumnFilters/columnFilters";
 import { ColumnFilterTags } from "../../../../../../../../common/Filters/components/ColumnFilterTags/columnFilterTags";
+import { MDXSection } from "../../../../../../../../common/Section/section.styles";
 import { Table } from "../../../../../../../../common/Table/table";
 import { useTable } from "./components/table/hook";
 import { StyledBox } from "./sourceDatasets.styles";
@@ -19,6 +21,11 @@ export const SourceDatasets = ({ data }: Props): JSX.Element => {
 
   return (
     <>
+      <FluidPaper>
+        <MDXSection>
+          <SourceDatasetsDescription />
+        </MDXSection>
+      </FluidPaper>
       <ColumnFilters table={table} />
       <ColumnFilterTags table={table} />
       <FluidPaper elevation={0}>

--- a/components/HCABioNetworks/Network/Atlas/components/SourceStudies/components/MainColumn/mainColumn.tsx
+++ b/components/HCABioNetworks/Network/Atlas/components/SourceStudies/components/MainColumn/mainColumn.tsx
@@ -1,6 +1,9 @@
+import { FluidPaper } from "@databiosphere/findable-ui/lib/components/common/Paper/paper.styles";
 import { BackPageContentSingleColumn } from "@databiosphere/findable-ui/lib/components/Layout/components/BackPage/backPageView.styles";
 import { JSX } from "react";
+import { SourceStudiesDescription } from "../../../../../../../../content";
 import { useAtlas } from "../../../../../../../../contexts/atlasContext";
+import { MDXSection } from "../../../../../../../common/Section/section.styles";
 import { SourceStudies } from "./tracker/sourceStudies";
 
 /**
@@ -11,6 +14,11 @@ export const MainColumn = (): JSX.Element => {
   const { trackerSourceStudies = [] } = useAtlas();
   return (
     <BackPageContentSingleColumn>
+      <FluidPaper>
+        <MDXSection>
+          <SourceStudiesDescription />
+        </MDXSection>
+      </FluidPaper>
       <SourceStudies data={trackerSourceStudies} />
     </BackPageContentSingleColumn>
   );

--- a/components/HCABioNetworks/Network/Atlas/components/SourceStudies/components/MainColumn/tracker/components/table/columns.ts
+++ b/components/HCABioNetworks/Network/Atlas/components/SourceStudies/components/MainColumn/tracker/components/table/columns.ts
@@ -9,7 +9,7 @@ const HCA_DATA_REPOSITORY = {
   cell: renderHCADataRepository,
   enableColumnFilter: false,
   enableSorting: false,
-  header: "HCA Data Repository",
+  header: "HCA Data Explorer",
   id: "hcaProjectId",
   meta: { width: "auto" },
 } as ColumnDef<TrackerSourceStudy>;

--- a/components/HCABioNetworks/Network/Atlas/components/common/Tabs/tabs.tsx
+++ b/components/HCABioNetworks/Network/Atlas/components/common/Tabs/tabs.tsx
@@ -11,19 +11,25 @@ import { useAtlas } from "contexts/atlasContext";
 import { useRouter } from "next/router";
 import { JSX } from "react";
 
+const ATLAS_OVERVIEW_TAB = {
+  label: "Atlas Overview",
+  value: NETWORKS_ATLAS_PATTERN,
+};
+
 const BASE_TABS = [
+  ATLAS_OVERVIEW_TAB,
   {
-    label: "Atlas Overview",
-    value: NETWORKS_ATLAS_PATTERN,
-  },
-  {
-    label: "Source Datasets",
+    label: "Source Studies",
     value: NETWORK_ATLAS_DATASETS_PATTERN,
   },
 ];
 
 const TRACKER_TABS = [
-  ...BASE_TABS,
+  ATLAS_OVERVIEW_TAB,
+  {
+    label: "Source Datasets",
+    value: NETWORK_ATLAS_DATASETS_PATTERN,
+  },
   {
     label: "Source Studies",
     value: NETWORK_ATLAS_SOURCE_STUDIES_PATTERN,

--- a/content/HCABioNetworks/Network/Atlas/Datasets/description.mdx
+++ b/content/HCABioNetworks/Network/Atlas/Datasets/description.mdx
@@ -1,1 +1,0 @@
-The datasets below are ingested in the HCA Data Portal and used in the creation of the related integrated atlas. Additional datasets may have been used in the creation of the atlas. See the atlas publication for the full list of source datasets for the atlas.

--- a/content/HCABioNetworks/Network/Atlas/SourceDatasets/description.mdx
+++ b/content/HCABioNetworks/Network/Atlas/SourceDatasets/description.mdx
@@ -1,0 +1,1 @@
+Source datasets are AnnData (`.h5ad`) files that conform to the [HCA metadata schema](/metadata) and were used to construct the atlas's integrated objects.

--- a/content/HCABioNetworks/Network/Atlas/SourceStudies/description.mdx
+++ b/content/HCABioNetworks/Network/Atlas/SourceStudies/description.mdx
@@ -1,0 +1,1 @@
+The studies below contributed datasets to this atlas. Primary data for some studies is available in the [HCA Data Explorer]({browserURL}).

--- a/content/index.tsx
+++ b/content/index.tsx
@@ -1,1 +1,2 @@
-export { default as AtlasDatasetsDescription } from "./HCABioNetworks/Network/Atlas/Datasets/description.mdx";
+export { default as SourceDatasetsDescription } from "./HCABioNetworks/Network/Atlas/SourceDatasets/description.mdx";
+export { default as SourceStudiesDescription } from "./HCABioNetworks/Network/Atlas/SourceStudies/description.mdx";

--- a/utils/atlasPages.ts
+++ b/utils/atlasPages.ts
@@ -64,6 +64,10 @@ export async function getContentStaticProps(
     return getTrackerContentStaticProps(atlas, network, tabName);
   }
 
+  // Non-tracker atlases list source studies (Azul projects) on the datasets route.
+  const nonTrackerTabName =
+    tabName === "Source Datasets" ? "Source Studies" : tabName;
+
   const {
     dataSource: { url },
   } = config();
@@ -91,7 +95,7 @@ export async function getContentStaticProps(
     props: {
       atlas: processAtlas(atlas, cxgDatasets),
       network: processNetwork(network, cxgDatasets),
-      pageTitle: `${atlas.name} - ${tabName}`,
+      pageTitle: `${atlas.name} - ${nonTrackerTabName}`,
       projectsResponses,
     },
   };


### PR DESCRIPTION
## Summary
- Renames the non-tracker atlas datasets tab from **Source Datasets** to **Source Studies** (route unchanged). Tracker atlases (Gut) keep both **Source Datasets** and **Source Studies** tabs.
- Replaces the old generic dataset disclaimer with two definition blocks: a **Source Datasets** definition for the tracker datasets tab and a **Source Studies** definition for both the tracker source-studies tab and the renamed non-tracker tab.
- Updates the pageTitle and no-results copy for non-tracker atlases so they match the new tab label.

Closes #3076

## Test plan
- [x] Non-tracker atlases (eye/retina-v1-0, brain-v1-0, cortex-v1-0, organoid-endoderm-v1-0, organoid-neural-v1-0, lung-v1-0) show a "Source Studies" tab in place of "Source Datasets"; the URL still ends in `/datasets`; the browser tab title reads "{atlas} - Source Studies".
- [x] When a non-tracker atlas has no projects, the empty state reads "No Source Studies".
- [x] Tracker atlas (gut-v1-0) keeps both tabs unchanged.
- [x] Tracker `/datasets` (gut-v1-0) shows the Source Datasets definition with a working link to the metadata page.
- [x] Tracker `/source-studies` (gut-v1-0) shows the Source Studies definition with a working link to the HCA Data Explorer (resolves via `{browserURL}` token).
- [x] Non-tracker renamed "Source Studies" tab shows the Source Studies definition.
- [x] Old disclaimer no longer appears anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="2543" height="1326" alt="image" src="https://github.com/user-attachments/assets/9530f633-6373-4bce-8dc8-2ff951849e55" />

<img width="2099" height="1194" alt="image" src="https://github.com/user-attachments/assets/22ffd436-6e85-4216-8218-dc246091ffb0" />

<img width="2549" height="951" alt="image" src="https://github.com/user-attachments/assets/b7e679f9-6c16-49b2-93c1-c206b5147dab" />


<img width="2549" height="989" alt="image" src="https://github.com/user-attachments/assets/85378264-e69a-4516-ab98-1141917e31a3" />

