### PR TITLE
feat: atlas datasets page: filter by integrated object (filter-only, no column) (#3083)

### DIFF
--- a/@types/network.ts
+++ b/@types/network.ts
@@ -221,7 +221,7 @@ export interface TrackerSourceDataset {
   fileName: string;
   geneCount: number;
   id: string;
-  integratedObjects: { id: string; name: string }[];
+  integratedObjects?: { id: string; name: string }[];
   publicationString: string | null;
   revision: number;
   sizeBytes: number;

--- a/@types/network.ts
+++ b/@types/network.ts
@@ -221,6 +221,7 @@ export interface TrackerSourceDataset {
   fileName: string;
   geneCount: number;
   id: string;
+  integratedObjects: { id: string; name: string }[];
   publicationString: string | null;
   revision: number;
   sizeBytes: number;

--- a/@types/network.ts
+++ b/@types/network.ts
@@ -214,6 +214,7 @@ export interface TrackerSourceDataset {
   assay: string[];
   baseFileName: string;
   cellCount: number;
+  componentAtlases?: { id: string; name: string }[];
   datasetAsset?: DatasetAsset;
   disease: string[];
   doi: string | null;
@@ -221,7 +222,6 @@ export interface TrackerSourceDataset {
   fileName: string;
   geneCount: number;
   id: string;
-  integratedObjects?: { id: string; name: string }[];
   publicationString: string | null;
   revision: number;
   sizeBytes: number;

--- a/components/HCABioNetworks/Network/Atlas/components/Datasets/components/MainColumn/tracker/components/table/accessor.ts
+++ b/components/HCABioNetworks/Network/Atlas/components/Datasets/components/MainColumn/tracker/components/table/accessor.ts
@@ -1,10 +1,11 @@
 import type { TrackerSourceDataset } from "../../../../../../../../../../../@types/network";
 
 /**
- * Returns the names of the integrated objects for a source dataset.
+ * Returns the names of the integrated objects (sourced from the legacy
+ * `componentAtlases` field on the tracker API) for a source dataset.
  * @param row - Tracker source dataset.
  * @returns array of integrated-object names.
  */
 export function buildIntegratedObjects(row: TrackerSourceDataset): string[] {
-  return row.integratedObjects?.map(({ name }) => name) ?? [];
+  return row.componentAtlases?.map(({ name }) => name) ?? [];
 }

--- a/components/HCABioNetworks/Network/Atlas/components/Datasets/components/MainColumn/tracker/components/table/accessor.ts
+++ b/components/HCABioNetworks/Network/Atlas/components/Datasets/components/MainColumn/tracker/components/table/accessor.ts
@@ -1,0 +1,10 @@
+import type { TrackerSourceDataset } from "../../../../../../../../../../../@types/network";
+
+/**
+ * Returns the names of the integrated objects for a source dataset.
+ * @param row - Tracker source dataset.
+ * @returns array of integrated-object names.
+ */
+export function buildIntegratedObjects(row: TrackerSourceDataset): string[] {
+  return row.integratedObjects?.map(({ name }) => name) ?? [];
+}

--- a/components/HCABioNetworks/Network/Atlas/components/Datasets/components/MainColumn/tracker/components/table/columns.ts
+++ b/components/HCABioNetworks/Network/Atlas/components/Datasets/components/MainColumn/tracker/components/table/columns.ts
@@ -10,6 +10,7 @@ import {
   buildPinnedNTagProps,
   renderPinnedNTagCell,
 } from "../../../../../../../../../../common/Table/components/Cell/components/PinnedNTagCell/utils";
+import { buildIntegratedObjects } from "./accessor";
 import {
   renderCellCount,
   renderDownload,
@@ -61,8 +62,7 @@ const DOWNLOAD = {
 } as ColumnDef<TrackerSourceDataset>;
 
 const INTEGRATED_OBJECTS = {
-  accessorFn: (row: TrackerSourceDataset) =>
-    row.integratedObjects?.map(({ name }) => name) ?? [],
+  accessorFn: buildIntegratedObjects,
   enableColumnFilter: true,
   filterFn: "arrIncludesSome",
   header: "Integrated Object",

--- a/components/HCABioNetworks/Network/Atlas/components/Datasets/components/MainColumn/tracker/components/table/columns.ts
+++ b/components/HCABioNetworks/Network/Atlas/components/Datasets/components/MainColumn/tracker/components/table/columns.ts
@@ -60,6 +60,15 @@ const DOWNLOAD = {
   meta: { width: "auto" },
 } as ColumnDef<TrackerSourceDataset>;
 
+const INTEGRATED_OBJECTS = {
+  accessorFn: (row: TrackerSourceDataset) =>
+    row.integratedObjects?.map(({ name }) => name) ?? [],
+  enableColumnFilter: true,
+  filterFn: "arrIncludesSome",
+  header: "Integrated Object",
+  id: "integratedObject",
+} as ColumnDef<TrackerSourceDataset>;
+
 const SOURCE_STUDY = {
   accessorKey: "publicationString",
   cell: renderSourceStudy,
@@ -99,4 +108,5 @@ export const COLUMNS: ColumnDef<TrackerSourceDataset>[] = [
   DISEASE,
   CELL_COUNT,
   DOWNLOAD,
+  INTEGRATED_OBJECTS,
 ];

--- a/components/HCABioNetworks/Network/Atlas/components/Datasets/components/MainColumn/tracker/components/table/hook.ts
+++ b/components/HCABioNetworks/Network/Atlas/components/Datasets/components/MainColumn/tracker/components/table/hook.ts
@@ -6,6 +6,7 @@ import { CORE_OPTIONS } from "../../../../../../../../../../common/Table/options
 import { FACETED_OPTIONS } from "../../../../../../../../../../common/Table/options/faceted/constants";
 import { SORTING_OPTIONS } from "../../../../../../../../../../common/Table/options/sorting/constants";
 import { COLUMNS } from "./columns";
+import { META } from "./meta";
 
 /**
  * Returns a configured TanStack table instance for tracker source datasets.
@@ -28,6 +29,7 @@ export const useTable = (
     initialState: {
       sorting: [{ desc: SORT_DIRECTION.ASCENDING, id: "title" }],
     },
+    meta: META,
     state: {
       columnVisibility: { integratedObject: false },
     },

--- a/components/HCABioNetworks/Network/Atlas/components/Datasets/components/MainColumn/tracker/components/table/hook.ts
+++ b/components/HCABioNetworks/Network/Atlas/components/Datasets/components/MainColumn/tracker/components/table/hook.ts
@@ -29,7 +29,7 @@ export const useTable = (
       sorting: [{ desc: SORT_DIRECTION.ASCENDING, id: "title" }],
     },
     state: {
-      columnVisibility: {},
+      columnVisibility: { integratedObject: false },
     },
   });
 };

--- a/components/HCABioNetworks/Network/Atlas/components/Datasets/components/MainColumn/tracker/components/table/meta.ts
+++ b/components/HCABioNetworks/Network/Atlas/components/Datasets/components/MainColumn/tracker/components/table/meta.ts
@@ -1,0 +1,17 @@
+import { ColumnFiltersTableMeta } from "@databiosphere/findable-ui/lib/components/Filter/components/adapters/tanstack/ColumnFiltersAdapter/types";
+import type { TrackerSourceDataset } from "../../../../../../../../../../../@types/network";
+
+export const META: ColumnFiltersTableMeta<TrackerSourceDataset> = {
+  categoryGroups: [
+    {
+      categoryConfigs: [
+        { key: "assay", label: "Assay" },
+        { key: "tissue", label: "Tissue" },
+        { key: "disease", label: "Disease" },
+        { key: "sourceStudy", label: "Source Study" },
+        { key: "integratedObject", label: "Integrated Object" },
+      ],
+      label: "",
+    },
+  ],
+};

--- a/components/common/Filters/components/ColumnFilters/columnFilters.tsx
+++ b/components/common/Filters/components/ColumnFilters/columnFilters.tsx
@@ -9,17 +9,17 @@ import { RowData } from "@tanstack/react-table";
 import { ComponentProps, JSX } from "react";
 import { StyledButton, StyledButtonGroup } from "./columnFilters.styles";
 import { Props } from "./types";
+import { buildColumnFilters } from "./utils";
 
 export const ColumnFilters = <T extends RowData>({
   table,
 }: Props<T>): JSX.Element | null => {
-  const columns = table.getAllColumns();
-  const columnFilters = columns.filter((column) => column.getCanFilter());
-  const enableColumnFilters = table.options.enableColumnFilters;
   const isDrawer = useMediaQuery(
     (theme: Theme) => theme.breakpoints.down(820),
     { noSsr: true }
   );
+
+  const enableColumnFilters = table.options.enableColumnFilters;
 
   if (!enableColumnFilters) return null;
 
@@ -30,6 +30,8 @@ export const ColumnFilters = <T extends RowData>({
         renderSurface={(props) => <Drawer Button={renderButton} {...props} />}
       />
     );
+
+  const columnFilters = buildColumnFilters(table);
 
   return (
     <StyledButtonGroup {...BUTTON_GROUP_PROPS.SECONDARY_OUTLINED}>

--- a/components/common/Filters/components/ColumnFilters/utils.ts
+++ b/components/common/Filters/components/ColumnFilters/utils.ts
@@ -1,0 +1,27 @@
+import { ColumnFiltersTableMeta } from "@databiosphere/findable-ui/lib/components/Filter/components/adapters/tanstack/ColumnFiltersAdapter/types";
+import { Column, RowData, Table } from "@tanstack/react-table";
+
+/**
+ * Returns filterable columns in the order declared by
+ * `table.options.meta.categoryGroups`, falling back to the table's column
+ * order when no group ordering is configured. Mirrors how the mobile drawer
+ * adapter (findable-ui) resolves filter order.
+ * @param table - TanStack table instance.
+ * @returns filterable columns in display order.
+ */
+export function buildColumnFilters<T extends RowData>(
+  table: Table<T>
+): Column<T>[] {
+  const { options } = table;
+  const { meta } = options;
+  const { categoryGroups } = (meta || {}) as ColumnFiltersTableMeta<T>;
+
+  if (!categoryGroups) {
+    return table.getAllColumns().filter(({ getCanFilter }) => getCanFilter());
+  }
+
+  return categoryGroups
+    .flatMap(({ categoryConfigs }) => categoryConfigs)
+    .map(({ key }) => table.getColumn(key))
+    .filter((column): column is Column<T> => Boolean(column?.getCanFilter()));
+}


### PR DESCRIPTION
## Summary

- Adds an **Integrated Object** filter to the atlas Source Datasets table — filter-only, no visible column.
- Adds `integratedObjects: { id: string; name: string }[]` to `TrackerSourceDataset` (optional until the backend ships the field).
- Hides the new column via `columnVisibility: { integratedObject: false }`, mirroring the filter-only pattern used by `journal` / `referenceAuthor` on the source studies table.
- Reorders the filter sidebar to **Assay, Tissue, Disease, Source Study, Integrated Object** via `meta.categoryGroups`. Extends the shared desktop `ColumnFilters` component to honor `meta.categoryGroups` (the findable-ui mobile drawer already honors it).

Closes #3083

Depends on `clevercanary/hca-atlas-tracker#1320` (backend exposes `integratedObjects` as a pass-through).

## Test plan

- [x] Build (`npm run build-dev:data-portal`) succeeds locally
- [x] Visit `/hca-bio-networks/gut/atlases/gut-v1-0/datasets`: an "Integrated Object" filter appears in the sidebar
- [ ] Filter applies correctly and narrows the table to rows that include the selected integrated object(s)
- [x] No new column is rendered in the table
- [ ] Filter sidebar order is Assay → Tissue → Disease → Source Study → Integrated Object (desktop and mobile drawer)

<img width="2560" height="1139" alt="image" src="https://github.com/user-attachments/assets/29139679-da40-4989-ae6e-8cdc46283014" />