### PR TITLE
feat: atlas source studies page: filter by integrated object (filter-only, no column) (#3084)

### DIFF
--- a/@types/network.ts
+++ b/@types/network.ts
@@ -233,12 +233,12 @@ export interface TrackerSourceDataset {
 
 export interface TrackerSourceStudy {
   cellxgeneCollectionId: string | null;
+  componentAtlases?: { id: string; name: string }[];
   contactEmail: string | null;
   doi: string | null;
   doiStatus: string;
   hcaProjectId: string | null;
   id: string;
-  integratedObjects?: { id: string; name: string }[];
   journal: string | null;
   publicationDate: string | null;
   referenceAuthor: string;

--- a/@types/network.ts
+++ b/@types/network.ts
@@ -238,6 +238,7 @@ export interface TrackerSourceStudy {
   doiStatus: string;
   hcaProjectId: string | null;
   id: string;
+  integratedObjects: { id: string; name: string }[];
   journal: string | null;
   publicationDate: string | null;
   referenceAuthor: string;

--- a/@types/network.ts
+++ b/@types/network.ts
@@ -238,7 +238,7 @@ export interface TrackerSourceStudy {
   doiStatus: string;
   hcaProjectId: string | null;
   id: string;
-  integratedObjects: { id: string; name: string }[];
+  integratedObjects?: { id: string; name: string }[];
   journal: string | null;
   publicationDate: string | null;
   referenceAuthor: string;

--- a/@types/network.ts
+++ b/@types/network.ts
@@ -237,12 +237,12 @@ export interface TrackerSourceDataset {
 
 export interface TrackerSourceStudy {
   cellxgeneCollectionId: string | null;
+  componentAtlases?: { id: string; name: string }[];
   contactEmail: string | null;
   doi: string | null;
   doiStatus: string;
   hcaProjectId: string | null;
   id: string;
-  integratedObjects?: { id: string; name: string }[];
   journal: string | null;
   publicationDate: string | null;
   referenceAuthor: string;

--- a/@types/network.ts
+++ b/@types/network.ts
@@ -242,6 +242,7 @@ export interface TrackerSourceStudy {
   doiStatus: string;
   hcaProjectId: string | null;
   id: string;
+  integratedObjects: { id: string; name: string }[];
   journal: string | null;
   publicationDate: string | null;
   referenceAuthor: string;

--- a/@types/network.ts
+++ b/@types/network.ts
@@ -242,7 +242,7 @@ export interface TrackerSourceStudy {
   doiStatus: string;
   hcaProjectId: string | null;
   id: string;
-  integratedObjects: { id: string; name: string }[];
+  integratedObjects?: { id: string; name: string }[];
   journal: string | null;
   publicationDate: string | null;
   referenceAuthor: string;

--- a/components/HCABioNetworks/Network/Atlas/components/SourceStudies/components/MainColumn/tracker/components/table/accessor.ts
+++ b/components/HCABioNetworks/Network/Atlas/components/SourceStudies/components/MainColumn/tracker/components/table/accessor.ts
@@ -1,6 +1,15 @@
 import type { TrackerSourceStudy } from "../../../../../../../../../../../@types/network";
 
 /**
+ * Returns the names of the integrated objects for a source study.
+ * @param row - Tracker source study.
+ * @returns array of integrated-object names.
+ */
+export function buildIntegratedObjects(row: TrackerSourceStudy): string[] {
+  return row.integratedObjects?.map(({ name }) => name) ?? [];
+}
+
+/**
  * Builds a formatted citation string for a source study.
  * - No DOI: "Author - Unpublished"
  * - DOI but missing date/journal: "Author"

--- a/components/HCABioNetworks/Network/Atlas/components/SourceStudies/components/MainColumn/tracker/components/table/accessor.ts
+++ b/components/HCABioNetworks/Network/Atlas/components/SourceStudies/components/MainColumn/tracker/components/table/accessor.ts
@@ -1,12 +1,13 @@
 import type { TrackerSourceStudy } from "../../../../../../../../../../../@types/network";
 
 /**
- * Returns the names of the integrated objects for a source study.
+ * Returns the names of the integrated objects (sourced from the legacy
+ * `componentAtlases` field on the tracker API) for a source study.
  * @param row - Tracker source study.
  * @returns array of integrated-object names.
  */
 export function buildIntegratedObjects(row: TrackerSourceStudy): string[] {
-  return row.integratedObjects?.map(({ name }) => name) ?? [];
+  return row.componentAtlases?.map(({ name }) => name) ?? [];
 }
 
 /**

--- a/components/HCABioNetworks/Network/Atlas/components/SourceStudies/components/MainColumn/tracker/components/table/columns.ts
+++ b/components/HCABioNetworks/Network/Atlas/components/SourceStudies/components/MainColumn/tracker/components/table/columns.ts
@@ -1,7 +1,7 @@
 import { sortingFn } from "@databiosphere/findable-ui/lib/components/Table/common/utils";
 import type { ColumnDef } from "@tanstack/react-table";
 import type { TrackerSourceStudy } from "../../../../../../../../../../../@types/network";
-import { buildSourceStudy } from "./accessor";
+import { buildIntegratedObjects, buildSourceStudy } from "./accessor";
 import { renderHCADataRepository, renderSourceStudy } from "./viewBuilder";
 
 const HCA_DATA_REPOSITORY = {
@@ -12,6 +12,14 @@ const HCA_DATA_REPOSITORY = {
   header: "HCA Data Explorer",
   id: "hcaProjectId",
   meta: { width: "auto" },
+} as ColumnDef<TrackerSourceStudy>;
+
+const INTEGRATED_OBJECTS = {
+  accessorFn: buildIntegratedObjects,
+  enableColumnFilter: true,
+  filterFn: "arrIncludesSome",
+  header: "Integrated Object",
+  id: "integratedObject",
 } as ColumnDef<TrackerSourceStudy>;
 
 const JOURNAL = {
@@ -55,4 +63,5 @@ export const COLUMNS: ColumnDef<TrackerSourceStudy>[] = [
   HCA_DATA_REPOSITORY,
   JOURNAL,
   REFERENCE_AUTHOR,
+  INTEGRATED_OBJECTS,
 ];

--- a/components/HCABioNetworks/Network/Atlas/components/SourceStudies/components/MainColumn/tracker/components/table/hook.ts
+++ b/components/HCABioNetworks/Network/Atlas/components/SourceStudies/components/MainColumn/tracker/components/table/hook.ts
@@ -33,7 +33,11 @@ export const useTable = (
     },
     meta: { browserUrl: config.browserURL },
     state: {
-      columnVisibility: { journal: false, referenceAuthor: false },
+      columnVisibility: {
+        integratedObject: false,
+        journal: false,
+        referenceAuthor: false,
+      },
     },
   });
 };


### PR DESCRIPTION
## Summary

- Adds an **Integrated Object** filter to the atlas Source Studies table — filter-only, no visible column.
- Adds `integratedObjects: { id: string; name: string }[]` to `TrackerSourceStudy`.
- Extends `columnVisibility` with `integratedObject: false`, mirroring the existing `journal` / `referenceAuthor` filter-only pattern.
- Extracts the names accessor into `accessor.ts` as `buildIntegratedObjects` (matches `buildSourceStudy` co-location).

Closes #3084

Depends on `clevercanary/hca-atlas-tracker#1321` (backend exposes `integratedObjects` as a pass-through). Verified against the live tracker API — the field is not present yet, so the accessor null-safes (`?? []`) until the backend ships.

## Test plan

- [x] Build (`npm run build-dev:data-portal`) succeeds locally
- [ ] After backend deploy: visit `/hca-bio-networks/gut/atlases/gut-v1-0/source-studies` — "Integrated Object" filter appears in the sidebar
- [ ] Filter applies correctly and narrows the table to rows that include the selected integrated object(s)
- [x] No new column is rendered in the table

<img width="2558" height="1120" alt="image" src="https://github.com/user-attachments/assets/de41f4a9-bbe5-4768-8623-d480d2755281" />
