### PR TITLE
chore: comment out gut atlas to hide unpublished tracker content (#3101)

### DIFF
--- a/constants/networks.ts
+++ b/constants/networks.ts
@@ -134,30 +134,31 @@ export const NETWORKS: Network[] = [
     path: "genetic-diversity",
   },
   {
-    atlases: [
-      {
-        coordinators: [
-          { email: "kkimler@broadinstitute.org", fullName: "Kyle Kimler" },
-          {
-            email: "christopher.lance@helmholtz-munich.de",
-            fullName: "Christopher Lance",
-          },
-        ],
-        datasets: [],
-        externalDatasets: [],
-        integratedAtlases: [],
-        key: GUT_V1_0,
-        name: "Human Gut Cell Atlas (HGCA) v1.0",
-        path: GUT_V1_0,
-        publications: [],
-        tracker: {
-          shortNameSlug: "gut",
-          version: "v1.0",
-        },
-        updatedAt: "",
-        version: "v1",
-      },
-    ],
+    atlases: [],
+    // atlases: [
+    //   {
+    //     coordinators: [
+    //       { email: "kkimler@broadinstitute.org", fullName: "Kyle Kimler" },
+    //       {
+    //         email: "christopher.lance@helmholtz-munich.de",
+    //         fullName: "Christopher Lance",
+    //       },
+    //     ],
+    //     datasets: [],
+    //     externalDatasets: [],
+    //     integratedAtlases: [],
+    //     key: GUT_V1_0,
+    //     name: "Human Gut Cell Atlas (HGCA) v1.0",
+    //     path: GUT_V1_0,
+    //     publications: [],
+    //     tracker: {
+    //       shortNameSlug: "gut",
+    //       version: "v1.0",
+    //     },
+    //     updatedAt: "",
+    //     version: "v1",
+    //   },
+    // ],
     contact: { email: "gut@humancellatlas.org" },
     coordinators: [
       { fullName: "Mike Snyder" },


### PR DESCRIPTION
## Summary

Closes #3101

The Gut atlas (`Human Gut Cell Atlas (HGCA) v1.0`) sources its content from the HCA Tracker. Gut cannot currently be published, so its atlas content is hidden from the portal.

This comments out the **entire gut atlas object** in the `gut` network's `atlases` array in `constants/networks.ts`, leaving `atlases: []`. Gut now behaves like every other unpublished network:

- No atlas page is generated (`getStaticPaths` no longer includes it; `fallback: false`)
- No build-time HCA Tracker fetch occurs for gut
- Easy to revert by uncommenting once Gut can be published

### Why comment out the whole atlas, not just `tracker`

Commenting out only the `tracker` object is **not** sufficient — it removes the publication gate in `getStaticPaths` and falls through to the non-tracker path, generating a live-but-empty atlas page. The whole atlas object must be commented out.

### Notes

- `GUT_V1_0` remains referenced by `NETWORK_ATLAS_CONTENT.gut`, so no unused-variable error.
- The `NETWORK_ATLAS_CONTENT.gut` entry is a passive lookup (read only by `useAtlasContent` for the current page); with no gut page generated it is never reached. Left in place for an easy revert.

## Verification

- ✅ `tsc --noEmit` — 0 errors
- ✅ `next lint` — no warnings or errors
- ✅ `npm run build-dev:data-portal` — succeeds; gut atlas no longer appears in generated pages
- No unit/e2e test infrastructure exists in this repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)