### PR TITLE
fix: update contact emails, rename constant, and replace Zendesk FAB with help page link

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -1,7 +1,7 @@
 import { Parameter } from "@databiosphere/findable-ui/lib/utils/replaceParameters";
 
 export const PARAMETERS: Parameter = {
-  emailHelp: "mailto:wrangler-team@data.humancellatlas.org",
   emailHcaSlack: "mailto:slack@humancellatlas.org",
+  emailHelp: "mailto:wrangler-team@data.humancellatlas.org",
   hcaOrg: "https://www.humancellatlas.org",
 };

--- a/common/constants.ts
+++ b/common/constants.ts
@@ -2,6 +2,6 @@ import { Parameter } from "@databiosphere/findable-ui/lib/utils/replaceParameter
 
 export const PARAMETERS: Parameter = {
   emailHelp: "mailto:data-help@humancellatlas.org",
-  emailHumanCellAtlas: "mailto:hca@humancellatlas.com",
+  emailHumanCellAtlas: "mailto:hca@humancellatlas.org",
   hcaOrg: "https://www.humancellatlas.org",
 };

--- a/common/constants.ts
+++ b/common/constants.ts
@@ -1,7 +1,7 @@
 import { Parameter } from "@databiosphere/findable-ui/lib/utils/replaceParameters";
 
 export const PARAMETERS: Parameter = {
-  emailHelp: "mailto:data-help@humancellatlas.org",
-  emailHumanCellAtlas: "mailto:slack@humancellatlas.org",
+  emailHelp: "mailto:wrangler-team@data.humancellatlas.org",
+  emailHcaSlack: "mailto:slack@humancellatlas.org",
   hcaOrg: "https://www.humancellatlas.org",
 };

--- a/common/constants.ts
+++ b/common/constants.ts
@@ -2,6 +2,6 @@ import { Parameter } from "@databiosphere/findable-ui/lib/utils/replaceParameter
 
 export const PARAMETERS: Parameter = {
   emailHelp: "mailto:data-help@humancellatlas.org",
-  emailHumanCellAtlas: "mailto:hca@humancellatlas.org",
+  emailHumanCellAtlas: "mailto:slack@humancellatlas.org",
   hcaOrg: "https://www.humancellatlas.org",
 };

--- a/docs/contact.mdx
+++ b/docs/contact.mdx
@@ -10,7 +10,7 @@ We are constantly improving the Data Portal to be a better resource for our comm
 
 ## Email us with questions
 
-Find something that’s not working right? Have questions about the Data Portal or the datasets? Email us at [data-help@humancellatlas.org]({emailHelp}) to ask questions or report issues.
+Find something that’s not working right? Have questions about the Data Portal or the datasets? Email us at [wrangler-team@data.humancellatlas.org]({emailHelp}) to ask questions or report issues.
 
 ## Register with the HCA
 
@@ -24,5 +24,5 @@ We use the Human Cell Atlas Slack workspace to communicate events, highlight new
 
 To join the conversation:
 
-1. Request an invitation to the HCA Slack from [slack@humancellatlas.org]({emailHumanCellAtlas}).
+1. Request an invitation to the HCA Slack from [slack@humancellatlas.org]({emailHcaSlack}).
 2. Add the **#dcp-users** channel and say hello.

--- a/docs/contact.mdx
+++ b/docs/contact.mdx
@@ -24,5 +24,5 @@ We use the Human Cell Atlas Slack workspace to communicate events, highlight new
 
 To join the conversation:
 
-1. Request an invitation to the HCA Slack from [hca@humancellatlas.com]({emailHumanCellAtlas}).
+1. Request an invitation to the HCA Slack from [hca@humancellatlas.org]({emailHumanCellAtlas}).
 2. Add the **#dcp-users** channel and say hello.

--- a/docs/contact.mdx
+++ b/docs/contact.mdx
@@ -24,5 +24,5 @@ We use the Human Cell Atlas Slack workspace to communicate events, highlight new
 
 To join the conversation:
 
-1. Request an invitation to the HCA Slack from [hca@humancellatlas.org]({emailHumanCellAtlas}).
+1. Request an invitation to the HCA Slack from [slack@humancellatlas.org]({emailHumanCellAtlas}).
 2. Add the **#dcp-users** channel and say hello.

--- a/docs/contact/join-the-discussion.mdx
+++ b/docs/contact/join-the-discussion.mdx
@@ -8,7 +8,7 @@ title: "Join the Discussion"
 
 The Human Cell Atlas is a community-driven effort. There are many opportunities to get involved.
 
-We use a Slack workspace to coordinate our efforts as we build the HCA Data Portal. This is an open group, and we welcome community members who want to be learn more about the project. Request an invitation to the HCA Slack from [hca@humancellatlas.com]({emailHumanCellAtlas}).
+We use a Slack workspace to coordinate our efforts as we build the HCA Data Portal. This is an open group, and we welcome community members who want to be learn more about the project. Request an invitation to the HCA Slack from [hca@humancellatlas.org]({emailHumanCellAtlas}).
 
 Some channels to explore:
 

--- a/docs/contact/join-the-discussion.mdx
+++ b/docs/contact/join-the-discussion.mdx
@@ -8,7 +8,7 @@ title: "Join the Discussion"
 
 The Human Cell Atlas is a community-driven effort. There are many opportunities to get involved.
 
-We use a Slack workspace to coordinate our efforts as we build the HCA Data Portal. This is an open group, and we welcome community members who want to be learn more about the project. Request an invitation to the HCA Slack from [slack@humancellatlas.org]({emailHumanCellAtlas}).
+We use a Slack workspace to coordinate our efforts as we build the HCA Data Portal. This is an open group, and we welcome community members who want to be learn more about the project. Request an invitation to the HCA Slack from [slack@humancellatlas.org]({emailHcaSlack}).
 
 Some channels to explore:
 

--- a/docs/contact/join-the-discussion.mdx
+++ b/docs/contact/join-the-discussion.mdx
@@ -8,7 +8,7 @@ title: "Join the Discussion"
 
 The Human Cell Atlas is a community-driven effort. There are many opportunities to get involved.
 
-We use a Slack workspace to coordinate our efforts as we build the HCA Data Portal. This is an open group, and we welcome community members who want to be learn more about the project. Request an invitation to the HCA Slack from [hca@humancellatlas.org]({emailHumanCellAtlas}).
+We use a Slack workspace to coordinate our efforts as we build the HCA Data Portal. This is an open group, and we welcome community members who want to be learn more about the project. Request an invitation to the HCA Slack from [slack@humancellatlas.org]({emailHumanCellAtlas}).
 
 Some channels to explore:
 

--- a/docs/guides/requesting-access-to-controlled-access-data.mdx
+++ b/docs/guides/requesting-access-to-controlled-access-data.mdx
@@ -81,7 +81,7 @@ The Datasets section of the Data Portal provides an interactive Data Explorer. P
 
    d. Click the blue **Attest** button and submit.
 
-   e. If you do not hear from the HCA DAC within two weeks, please contact HCA support at [data-help@humancellatlas.org]({emailHelp}).
+   e. If you do not hear from the HCA DAC within two weeks, please contact HCA support at [wrangler-team@data.humancellatlas.org]({emailHelp}).
 
 ![Attest](/hca-bio-networks/guides/attest.png)
 

--- a/docs/help.mdx
+++ b/docs/help.mdx
@@ -16,7 +16,7 @@ We use the Human Cell Atlas Slack workspace to communicate events, highlight new
 
 To join the conversation:
 
-1. Request an invitation to the HCA Slack from [hca@humancellatlas.org]({emailHumanCellAtlas}).
+1. Request an invitation to the HCA Slack from [slack@humancellatlas.org]({emailHumanCellAtlas}).
 2. Add the **#dcp-users** channel and say hello.
 
 ## FAQs

--- a/docs/help.mdx
+++ b/docs/help.mdx
@@ -16,7 +16,7 @@ We use the Human Cell Atlas Slack workspace to communicate events, highlight new
 
 To join the conversation:
 
-1. Request an invitation to the HCA Slack from [hca@humancellatlas.com]({emailHumanCellAtlas}).
+1. Request an invitation to the HCA Slack from [hca@humancellatlas.org]({emailHumanCellAtlas}).
 2. Add the **#dcp-users** channel and say hello.
 
 ## FAQs

--- a/docs/help.mdx
+++ b/docs/help.mdx
@@ -1,12 +1,12 @@
 ---
 date: "2018-05-03"
-description: "If you have questions or issues to report please email data-help@humancellatlas.org."
+description: "If you have questions or issues to report please email wrangler-team@data.humancellatlas.org."
 title: "Get Help"
 ---
 
 # Get Help
 
-If you have questions or issues to report please email [data-help@humancellatlas.org]({emailHelp}).
+If you have questions or issues to report please email [wrangler-team@data.humancellatlas.org]({emailHelp}).
 
 ## Join the Data Portal slack community
 
@@ -16,7 +16,7 @@ We use the Human Cell Atlas Slack workspace to communicate events, highlight new
 
 To join the conversation:
 
-1. Request an invitation to the HCA Slack from [slack@humancellatlas.org]({emailHumanCellAtlas}).
+1. Request an invitation to the HCA Slack from [slack@humancellatlas.org]({emailHcaSlack}).
 2. Add the **#dcp-users** channel and say hello.
 
 ## FAQs
@@ -67,4 +67,4 @@ Visit the _Contact_ page to learn how to collaborate with us and to reach us wit
 
 #### How can I reuse parts of the HCA Data Portal?
 
-One of our goals is to make the HCA Data Portal code open and reusable to the community. For now, contact us at [data-help@humancellatlas.org]({emailHelp}) with questions about reusing our code. Stay tuned for more information about reusing code in the _Intro_ section of the _Data Portal_.
+One of our goals is to make the HCA Data Portal code open and reusable to the community. For now, contact us at [wrangler-team@data.humancellatlas.org]({emailHelp}) with questions about reusing our code. Stay tuned for more information about reusing code in the _Intro_ section of the _Data Portal_.

--- a/docs/privacy.mdx
+++ b/docs/privacy.mdx
@@ -114,7 +114,7 @@ You may choose not to visit or use or participate in HCA Data Portal Services. I
 
 ### Questions and Complaints
 
-If you have questions or complaints about our treatment of your Personal Data, or have a request to delete your data, please feel free to contact [data-help@humancellatlas.org]({emailHelp}).\
+If you have questions or complaints about our treatment of your Personal Data, or have a request to delete your data, please feel free to contact [wrangler-team@data.humancellatlas.org]({emailHelp}).\
 Effective Date: This statement is effective as of July 12, 2022.
 
 ## Privacy Notice for Human Cell Atlas Data Portal Public Website for Individuals outside of the European Economic Area
@@ -206,5 +206,5 @@ You may choose not to visit or use or participate in HCA Data Portal Services. I
 
 ### Questions and Complaints
 
-If you have questions or complaints about our treatment of your Personal Data, or have a request to delete your data, please feel free to contact [data-help@humancellatlas.org]({emailHelp}).\
+If you have questions or complaints about our treatment of your Personal Data, or have a request to delete your data, please feel free to contact [wrangler-team@data.humancellatlas.org]({emailHelp}).\
 Effective Date: This statement is effective as of July 12, 2022.

--- a/site-config/data-portal/dev/layout/floating.ts
+++ b/site-config/data-portal/dev/layout/floating.ts
@@ -1,20 +1,11 @@
-import { REQUEST_FIELD_ID } from "@databiosphere/findable-ui/lib/components/Support/components/SupportRequest/components/SupportRequestForm/common/entities";
+import { ViewSupport } from "@databiosphere/findable-ui/lib/components/Support/components/ViewSupport/viewSupport";
 import {
   ComponentConfig,
   FloatingConfig,
 } from "@databiosphere/findable-ui/lib/config/entities";
 import * as C from "../../../../components";
+import { ROUTES } from "../../../../routes/constants";
 import * as V from "../../../../viewModelBuilders/viewModelBuilders";
-
-const ZENDESK_FIELD_ID: Record<REQUEST_FIELD_ID, number> = {
-  DESCRIPTION: 360007369412,
-  EMAIL: 360012782111,
-  SUBJECT: 360007369392,
-  TICKET_FORM_ID: 360000932232,
-  TYPE: 360012744452,
-};
-const ZENDESK_REQUEST_URL = "https://support.terra.bio/api/v2/requests.json";
-const ZENDESK_UPLOAD_URL = "https://support.terra.bio/api/v2/uploads";
 
 export const floating: FloatingConfig = {
   components: [
@@ -23,14 +14,10 @@ export const floating: FloatingConfig = {
       viewBuilder: V.buildCookieBanner,
     } as ComponentConfig<typeof C.CookieBanner>,
     {
-      component: C.SupportRequest,
+      component: ViewSupport,
       props: {
-        supportRequest: {
-          FIELD_ID: ZENDESK_FIELD_ID,
-          requestURL: ZENDESK_REQUEST_URL,
-          uploadURL: ZENDESK_UPLOAD_URL,
-        },
+        url: ROUTES.HELP,
       },
-    } as ComponentConfig<typeof C.SupportRequest>,
+    } as ComponentConfig<typeof ViewSupport>,
   ],
 };


### PR DESCRIPTION
## Ticket
Closes #3104

## Summary
- Fixed the HCA Slack invitation email from `hca@humancellatlas.com` to `slack@humancellatlas.org`
- Updated help/support email from `data-help@humancellatlas.org` to `wrangler-team@data.humancellatlas.org`
- Renamed `emailHumanCellAtlas` constant to `emailHcaSlack`
- Changed FAB from Zendesk support form to link to the help page

## Test plan
- [ ] Verify Slack email link on `/help`, `/contact`, and `/contact/join-the-discussion` points to `slack@humancellatlas.org`
- [ ] Verify help email link on `/help`, `/contact`, `/privacy`, and `/guides/requesting-access-to-controlled-access-data` points to `wrangler-team@data.humancellatlas.org`
- [ ] Verify FAB links to `/help` instead of opening a Zendesk form

🤖 Generated with [Claude Code](https://claude.com/claude-code)