### PR TITLE
feat: sanitize crossref-fetched publication titles in complete-biccn-publications script (#3089)

### DIFF
--- a/components/HCABioNetworks/Network/components/Publications/components/MainColumn/components/Publication/publication.tsx
+++ b/components/HCABioNetworks/Network/components/Publications/components/MainColumn/components/Publication/publication.tsx
@@ -26,8 +26,8 @@ export const Publication = ({ publication }: PublicationProps): JSX.Element => {
           <CardSection>
             <CardContent>
               {/* Title and citation render as plain text (no Markdown). Crossref
-              titles may contain markup (e.g. <sup>, <i>); such formatting must
-              be encoded as Unicode in biccn-publications.json — see the NOTE in
+              titles are sanitized into plain text (markup mapped to Unicode or
+              stripped, entities decoded) by cleanTitle in
               scripts/complete-biccn-publications.ts. */}
               <CardTitle>{publication.title}</CardTitle>
               <CardSecondaryTitle>

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,6 +69,7 @@
         "eslint-plugin-sonarjs": "^4.0.2",
         "eslint-plugin-sort-destructure-keys": "^3",
         "got": "^14.4.5",
+        "html-entities": "^2.6.0",
         "husky": "^9.1.7",
         "next-sitemap": "^4.2.3",
         "prettier": "^3.7.4",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "eslint-plugin-sonarjs": "^4.0.2",
     "eslint-plugin-sort-destructure-keys": "^3",
     "got": "^14.4.5",
+    "html-entities": "^2.6.0",
     "husky": "^9.1.7",
     "next-sitemap": "^4.2.3",
     "prettier": "^3.7.4",

--- a/scripts/complete-biccn-publications.ts
+++ b/scripts/complete-biccn-publications.ts
@@ -63,8 +63,7 @@ getPublications();
  * markup), then superscript/subscript tags are mapped to Unicode where possible
  * (e.g. Ca<sup>2+</sup> -> Ca²⁺), remaining HTML tags are stripped (italic
  * species names lose styling but stay readable), and whitespace is collapsed.
- * The function is idempotent over decoded text, so re-running over an
- * already-clean title leaves it unchanged.
+ * Applied once to each title when it is first fetched from Crossref.
  * @param raw - Raw Crossref title.
  * @returns sanitized title.
  */
@@ -136,14 +135,11 @@ async function getPublications(): Promise<void> {
   for (const publications of Object.values(biccnPublications)) {
     for (const publication of publications) {
       if (publication.title === undefined) {
-        // If title is missing, add info from Crossref (already sanitized).
+        // If title is missing, add info from Crossref (title sanitized there).
         const info = await getPublication(publication.doi);
         if (info === null)
           throw new Error(`Publication unavailable for ${publication.doi}`);
         Object.assign(publication, info);
-      } else {
-        // Re-sanitize existing titles so the file self-heals on every run.
-        publication.title = cleanTitle(publication.title);
       }
     }
   }

--- a/scripts/complete-biccn-publications.ts
+++ b/scripts/complete-biccn-publications.ts
@@ -1,5 +1,6 @@
 import { promises as fsp } from "fs";
 import got, { HTTPError } from "got";
+import { decode } from "html-entities";
 import { BICCNPublication, CrossrefWork } from "../@types/network";
 
 interface PublicationInfo {
@@ -11,34 +12,72 @@ interface PublicationInfo {
 
 const PUBLICATIONS_PATH = "constants/biccn-publications.json";
 
+// Maps characters to their Unicode subscript equivalents. "−" is the Unicode
+// minus sign (U+2212), which entities such as &minus; decode to.
+const SUBSCRIPTS: Record<string, string> = {
+  "(": "₍",
+  ")": "₎",
+  "+": "₊",
+  "-": "₋",
+  "0": "₀",
+  "1": "₁",
+  "2": "₂",
+  "3": "₃",
+  "4": "₄",
+  "5": "₅",
+  "6": "₆",
+  "7": "₇",
+  "8": "₈",
+  "9": "₉",
+  "=": "₌",
+  "−": "₋",
+};
+
+// Maps characters to their Unicode superscript equivalents. "−" is the Unicode
+// minus sign (U+2212), which entities such as &minus; decode to.
+const SUPERSCRIPTS: Record<string, string> = {
+  "(": "⁽",
+  ")": "⁾",
+  "+": "⁺",
+  "-": "⁻",
+  "0": "⁰",
+  "1": "¹",
+  "2": "²",
+  "3": "³",
+  "4": "⁴",
+  "5": "⁵",
+  "6": "⁶",
+  "7": "⁷",
+  "8": "⁸",
+  "9": "⁹",
+  "=": "⁼",
+  n: "ⁿ",
+  "−": "⁻",
+};
+
 getPublications();
 
-async function getPublications(): Promise<void> {
-  const biccnPublications = JSON.parse(
-    await fsp.readFile(PUBLICATIONS_PATH, "utf8")
-  ) as Record<
-    string,
-    (Partial<BICCNPublication> & Pick<BICCNPublication, "doi">)[]
-  >;
-
-  for (const publications of Object.values(biccnPublications)) {
-    for (const publication of publications) {
-      if (publication.title === undefined) {
-        // If title is missing, add info from Crossref
-        const info = await getPublication(publication.doi);
-        if (info === null)
-          throw new Error(`Publication unavailable for ${publication.doi}`);
-        Object.assign(publication, info);
-      }
-    }
-  }
-
-  await fsp.writeFile(
-    PUBLICATIONS_PATH,
-    JSON.stringify(biccnPublications, undefined, 2) + "\n"
-  );
-
-  console.log(`Wrote ${PUBLICATIONS_PATH}`);
+/**
+ * Sanitizes a Crossref-supplied title for plain-text rendering. HTML entities
+ * are decoded first (so entity-encoded markup is handled the same as literal
+ * markup), then superscript/subscript tags are mapped to Unicode where possible
+ * (e.g. Ca<sup>2+</sup> -> Ca²⁺), remaining HTML tags are stripped (italic
+ * species names lose styling but stay readable), and whitespace is collapsed.
+ * The function is idempotent over decoded text, so re-running over an
+ * already-clean title leaves it unchanged.
+ * @param raw - Raw Crossref title.
+ * @returns sanitized title.
+ */
+function cleanTitle(raw: string): string {
+  // Decode entities exactly once (standard HTML semantics); strict scope
+  // requires a terminating ";", so ampersand-prefixed prose (e.g. "Tom&notit")
+  // is left intact rather than greedily matched to a legacy entity.
+  const decoded = decode(raw, { scope: "strict" });
+  const withScripts = mapScriptTags(decoded);
+  // Strip HTML tags only — the leading tag-name letter prevents inequality
+  // operators (e.g. "regions <0.5 mm and >2 mm") from being deleted.
+  const withoutTags = withScripts.replace(/<\/?[a-z][^<>]*>/gi, "");
+  return withoutTags.replace(/\s+/g, " ").trim();
 }
 
 async function getPublication(doi: string): Promise<PublicationInfo | null> {
@@ -58,22 +97,18 @@ async function getPublication(doi: string): Promise<PublicationInfo | null> {
       ["short-container-title"]: shortContainerTitle,
       title: [title],
     } = JSON.parse(response.body).message as CrossrefWork;
-    // NOTE: Crossref titles can contain markup (e.g. <sup>, <i>) and are stored
-    // verbatim here. The Publications UI renders titles as plain text (no
-    // Markdown/HTML), so any such markup currently renders literally. This
-    // script may need upgrading to normalise titles — superscripts/subscripts
-    // map cleanly to Unicode (e.g. Na<sup>+</sup> -> Na⁺), but italics (<i>,
-    // <em>) have no accessible Unicode equivalent and would need a different
-    // approach (e.g. re-introducing a server-rendered Markdown title).
+    // Crossref titles can contain markup (e.g. <sup>, <i>) and HTML entities;
+    // cleanTitle normalises them for the plain-text Publications UI.
     const journal =
       containerTitle[0] || shortContainerTitle[0] || institution?.[0].name;
     if (!journal) throw new Error("No journal name found");
+    if (!title) throw new Error("No title found");
     return {
       authors: author.map((a) =>
         "name" in a ? a.name : `${a.given} ${a.family}`
       ),
       journal,
-      title,
+      title: cleanTitle(title),
       year: published["date-parts"][0][0],
     };
   } catch (e) {
@@ -88,4 +123,74 @@ async function getPublication(doi: string): Promise<PublicationInfo | null> {
     }
     return null;
   }
+}
+
+async function getPublications(): Promise<void> {
+  const biccnPublications = JSON.parse(
+    await fsp.readFile(PUBLICATIONS_PATH, "utf8")
+  ) as Record<
+    string,
+    (Partial<BICCNPublication> & Pick<BICCNPublication, "doi">)[]
+  >;
+
+  for (const publications of Object.values(biccnPublications)) {
+    for (const publication of publications) {
+      if (publication.title === undefined) {
+        // If title is missing, add info from Crossref (already sanitized).
+        const info = await getPublication(publication.doi);
+        if (info === null)
+          throw new Error(`Publication unavailable for ${publication.doi}`);
+        Object.assign(publication, info);
+      } else {
+        // Re-sanitize existing titles so the file self-heals on every run.
+        publication.title = cleanTitle(publication.title);
+      }
+    }
+  }
+
+  await fsp.writeFile(
+    PUBLICATIONS_PATH,
+    JSON.stringify(biccnPublications, undefined, 2) + "\n"
+  );
+
+  console.log(`Wrote ${PUBLICATIONS_PATH}`);
+}
+
+/**
+ * Maps superscript and subscript tags to their Unicode equivalents, falling
+ * back to the tag's text content when a character has no Unicode equivalent.
+ * @param value - Value containing sup/sub markup.
+ * @returns value with sup/sub markup mapped to Unicode.
+ */
+function mapScriptTags(value: string): string {
+  return value
+    .replace(
+      /<sup>([^<]*)<\/sup>/gi,
+      (_match, content) => toUnicodeScript(content, SUPERSCRIPTS) ?? content
+    )
+    .replace(
+      /<sub>([^<]*)<\/sub>/gi,
+      (_match, content) => toUnicodeScript(content, SUBSCRIPTS) ?? content
+    );
+}
+
+/**
+ * Maps each character of the given content to its Unicode equivalent, or null
+ * if any character is unmappable.
+ * @param content - Tag text content.
+ * @param map - Character-to-Unicode map.
+ * @returns mapped content, or null when any character is unmappable.
+ */
+function toUnicodeScript(
+  content: string,
+  map: Record<string, string>
+): string | null {
+  let result = "";
+  // Trim surrounding whitespace (e.g. "<sup> + </sup>"); internal whitespace
+  // is left in place so spaced tokens fall back to plain text rather than merge.
+  for (const char of content.trim()) {
+    if (!(char in map)) return null;
+    result += map[char];
+  }
+  return result;
 }


### PR DESCRIPTION
## Summary

`scripts/complete-biccn-publications.ts` fetches missing publication metadata from Crossref, whose `title` field can contain JATS/HTML markup (`<sup>`, `<sub>`, `<i>`) and HTML entities. The Publications UI renders titles as plain text (the `MarkdownRenderer` swap was reverted in #3087), so such markup would render literally.

This adds a `cleanTitle` helper, applied to each title when it is **fetched** from Crossref. Pipeline:

1. **Decode HTML entities** once, `scope: "strict"` (so `&alpha;`/`&minus;`/`&#x2014;` decode, but ampersand-prefixed prose like `Tom&notit` is left intact and legitimately single-escaped text isn't over-decoded).
2. **Map sup/sub → Unicode**, including charged-ion counts: `Ca<sup>2+</sup>` → Ca²⁺, `HCO<sub>3</sub><sup>-</sup>` → HCO₃⁻.
3. **Strip remaining HTML tags** — anchored to a leading tag-name letter so inequality operators (`regions <0.5 mm and >2 mm`) are **not** deleted.
4. **Collapse whitespace.**

Sanitization runs **once per title, at fetch time** — it deliberately does not re-process already-stored titles, since `decode` peels exactly one entity layer per call (correct HTML semantics) and re-running would not converge for multiply-encoded input. Existing titles are already clean.

Italic species names lose styling (no accessible Unicode equivalent) but stay readable — the accepted trade-off from #3087. Adds `html-entities` as a **devDependency** (consistent with `got`/`esrun`).

Closes #3089

## Verification
- Script runs clean over `constants/biccn-publications.json` → **no diff**; the Na⁺/K⁺ paper title (hand-cleaned in #3087) is preserved (and untouched on re-run).
- Injected dirty titles confirm correct mapping/decoding/stripping, inequality preservation, strict-entity handling, and spaced sup/sub fallback.
- tsc / eslint / prettier clean; dev build passes.
- Three high-effort review rounds; final design resolves the decode idempotency/over-decode tension by sanitizing once at fetch.

## Notes
- `cleanTitle`/`mapScriptTags`/`toUnicodeScript` are pure functions and would be ideal unit-test targets if/when a test framework is added to data-portal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)