### PR TITLE
feat: searchview: encode pagination index in url query string (#3088)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "next",
       "version": "2.14.1",
       "dependencies": {
-        "@databiosphere/findable-ui": "^54.1.0",
+        "@databiosphere/findable-ui": "^55.0.0",
         "@emotion/react": "^11",
         "@emotion/server": "^11",
         "@emotion/styled": "^11",
@@ -633,9 +633,9 @@
       "license": "MIT"
     },
     "node_modules/@databiosphere/findable-ui": {
-      "version": "54.1.0",
-      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-54.1.0.tgz",
-      "integrity": "sha512-zN1hqsrPHc5gT6orAVUDWw7clGua5lISA/r3dkK2oyCL+XfIUqTh4TiTamHuK77NbJKraW7XRFejViY1imzP/w==",
+      "version": "55.0.0",
+      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-55.0.0.tgz",
+      "integrity": "sha512-BkzNX1R76mdY8hvdLGFaDNhi1+H7iq7PwRnGNqTYH82YaRBmQOWPozojkLqsesu8Nlg9JL6V+59cqFX1941iuQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": "22.13.0"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "get-cellxgene-projects": "esrun ./scripts/get-cellxgene-projects.ts"
   },
   "dependencies": {
-    "@databiosphere/findable-ui": "^54.1.0",
+    "@databiosphere/findable-ui": "^55.0.0",
     "@emotion/react": "^11",
     "@emotion/server": "^11",
     "@emotion/styled": "^11",

--- a/views/SearchView/components/Pagination/hooks/UsePagination/hook.ts
+++ b/views/SearchView/components/Pagination/hooks/UsePagination/hook.ts
@@ -1,0 +1,26 @@
+import { useSearchParams } from "next/navigation";
+import Router, { useRouter } from "next/router";
+import { useCallback } from "react";
+import { UsePagination } from "./types";
+import { getPaginationParams } from "./utils";
+
+/**
+ * Hook facilitating pagination by encoding the search index in the URL.
+ * @returns pagination functionality.
+ */
+export const usePagination = (): UsePagination => {
+  const { pathname } = useRouter();
+  const searchParams = useSearchParams();
+
+  const onPaginate = useCallback(
+    (searchIndex: number): void => {
+      Router.push({
+        pathname,
+        search: getPaginationParams(searchParams, searchIndex).toString(),
+      });
+    },
+    [pathname, searchParams]
+  );
+
+  return { onPaginate };
+};

--- a/views/SearchView/components/Pagination/hooks/UsePagination/types.ts
+++ b/views/SearchView/components/Pagination/hooks/UsePagination/types.ts
@@ -1,0 +1,3 @@
+export interface UsePagination {
+  onPaginate: (searchIndex: number) => void;
+}

--- a/views/SearchView/components/Pagination/hooks/UsePagination/utils.ts
+++ b/views/SearchView/components/Pagination/hooks/UsePagination/utils.ts
@@ -1,0 +1,18 @@
+import { SEARCH_PARAMETERS } from "@databiosphere/findable-ui/lib/components/Layout/components/Header/components/Content/components/Actions/components/Search/components/SearchBar/common/constants";
+import { ReadonlyURLSearchParams } from "next/navigation";
+
+/**
+ * Returns the search params with the pagination index applied, preserving the
+ * existing search term and category.
+ * @param searchParams - Current search params.
+ * @param searchIndex - Search index (start index).
+ * @returns updated search params.
+ */
+export function getPaginationParams(
+  searchParams: ReadonlyURLSearchParams | null,
+  searchIndex: number
+): URLSearchParams {
+  const params = new URLSearchParams(searchParams?.toString());
+  params.set(SEARCH_PARAMETERS.START, searchIndex.toString());
+  return params;
+}

--- a/views/SearchView/components/Pagination/pagination.tsx
+++ b/views/SearchView/components/Pagination/pagination.tsx
@@ -2,18 +2,18 @@ import { IconButton } from "@databiosphere/findable-ui/lib/components/common/Ico
 import EastRoundedIcon from "@mui/icons-material/EastRounded";
 import WestRoundedIcon from "@mui/icons-material/WestRounded";
 import { JSX } from "react";
-import { OnSearchFn, SearchPagination } from "../../hooks/common/entities";
+import { SearchPagination } from "../../hooks/common/entities";
+import { usePagination } from "./hooks/UsePagination/hook";
 import { PaginationActions, PaginationView } from "./pagination.styles";
 
 interface PaginationProps {
-  onSearch: OnSearchFn;
   pagination?: SearchPagination;
 }
 
 export const Pagination = ({
-  onSearch,
   pagination,
 }: PaginationProps): JSX.Element | null => {
+  const { onPaginate } = usePagination();
   if (!pagination) return null;
   return (
     <PaginationView>
@@ -22,16 +22,14 @@ export const Pagination = ({
           color="secondary"
           disabled={pagination.previousPage === 0}
           Icon={WestRoundedIcon}
-          onClick={(): void =>
-            onSearch({ searchIndex: pagination.previousPage })
-          }
+          onClick={(): void => onPaginate(pagination.previousPage)}
           size="medium"
         />
         <IconButton
           color="secondary"
           disabled={pagination.nextPage === 0}
           Icon={EastRoundedIcon}
-          onClick={(): void => onSearch({ searchIndex: pagination.nextPage })}
+          onClick={(): void => onPaginate(pagination.nextPage)}
           size="medium"
         />
       </PaginationActions>

--- a/views/SearchView/components/Results/results.tsx
+++ b/views/SearchView/components/Results/results.tsx
@@ -7,11 +7,11 @@ import { CardActionArea } from "@databiosphere/findable-ui/lib/components/common
 import { CardText } from "@databiosphere/findable-ui/lib/components/common/Card/components/CardText/cardText";
 import { CardTitle } from "@databiosphere/findable-ui/lib/components/common/Card/components/CardTitle/cardTitle";
 import { RoundedCard } from "@databiosphere/findable-ui/lib/components/common/Card/components/RoundedCard/roundedCard";
-import { RoundedPaper } from "@databiosphere/findable-ui/lib/components/common/Paper/paper.styles";
 import { NoResults } from "@databiosphere/findable-ui/lib/components/NoResults/noResults";
 import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
 import { Typography as MTypography } from "@mui/material";
 import { JSX } from "react";
+import { StyledRoundedPaper } from "../../searchView.styles";
 import { ResultsView } from "./results.styles";
 
 interface ResultsProps {
@@ -20,7 +20,11 @@ interface ResultsProps {
 
 export const Results = ({ results }: ResultsProps): JSX.Element => {
   if (!results)
-    return <NoResults Paper={RoundedPaper} title="No results found." />;
+    return (
+      <StyledRoundedPaper>
+        <NoResults Paper={null} title="No results found." />
+      </StyledRoundedPaper>
+    );
   return (
     <ResultsView>
       {results.map(({ cardUrl, secondaryTitle, text, title }, i) => (

--- a/views/SearchView/hooks/common/constants.ts
+++ b/views/SearchView/hooks/common/constants.ts
@@ -11,3 +11,11 @@ export const SEARCH_ENGINE_PARAMETERS = {
 export const SEARCH_ENGINE_PARAMETER_SAFE = "active";
 
 export const SEARCH_ENGINE_PATH = "/customsearch/v1";
+
+/**
+ * Google Custom Search returns 10 results per page and only paginates the first
+ * 100 results, so the last valid start index is 91 (results 91–100). A larger
+ * start index (e.g. from a hand-edited or stale URL) is clamped to this value to
+ * avoid requesting an out-of-range page that returns no results.
+ */
+export const SEARCH_ENGINE_MAX_START_INDEX = 91;

--- a/views/SearchView/hooks/common/constants.ts
+++ b/views/SearchView/hooks/common/constants.ts
@@ -13,6 +13,12 @@ export const SEARCH_ENGINE_PARAMETER_SAFE = "active";
 export const SEARCH_ENGINE_PATH = "/customsearch/v1";
 
 /**
+ * Google Custom Search uses 1-based pagination, so the first results page starts
+ * at index 1. An absent or invalid start param defaults to this.
+ */
+export const SEARCH_ENGINE_MIN_START_INDEX = 1;
+
+/**
  * Google Custom Search returns 10 results per page and only paginates the first
  * 100 results, so the last valid start index is 91 (results 91–100). A larger
  * start index (e.g. from a hand-edited or stale URL) is clamped to this value to

--- a/views/SearchView/hooks/common/entities.ts
+++ b/views/SearchView/hooks/common/entities.ts
@@ -1,18 +1,8 @@
-import { ReadonlyURLSearchParams } from "next/navigation";
-
 export interface Error {
   code: number;
   message: string;
   status: string;
 }
-
-export type OnSearchFn = ({
-  searchIndex,
-  searchParams,
-}: {
-  searchIndex?: number;
-  searchParams?: ReadonlyURLSearchParams;
-}) => void;
 
 export interface SearchPagination {
   nextPage: number;

--- a/views/SearchView/hooks/common/utils.ts
+++ b/views/SearchView/hooks/common/utils.ts
@@ -3,6 +3,7 @@ import { SEARCH_PARAMETERS } from "@databiosphere/findable-ui/lib/components/Lay
 import { ReadonlyURLSearchParams } from "next/navigation";
 import { SEARCH_CATEGORY } from "../../common/constants";
 import {
+  SEARCH_ENGINE_MAX_START_INDEX,
   SEARCH_ENGINE_PARAMETERS,
   SEARCH_ENGINE_PARAMETER_ID,
   SEARCH_ENGINE_PARAMETER_SAFE,
@@ -13,6 +14,19 @@ import {
   SearchResponse,
   SearchResponseError,
 } from "./entities";
+
+/**
+ * Returns the search category encoded in the URL; null when absent or invalid.
+ * @param searchParams - Search query and category parameters.
+ * @returns search category.
+ */
+export function getCategory(
+  searchParams: ReadonlyURLSearchParams | null
+): SEARCH_CATEGORY | null {
+  const value = getSearchParamValue(searchParams, SEARCH_PARAMETERS.CATEGORY);
+  if (isCategory(value)) return value;
+  return null;
+}
 
 /**
  * Returns request parameters for configured search engine.
@@ -78,6 +92,21 @@ export function getRequestURL(
 }
 
 /**
+ * Returns the search index (start index) encoded in the URL pagination param,
+ * clamped to the range the search engine supports.
+ * @param searchParams - Search query and category parameters.
+ * @returns search index; 0 when the param is absent or invalid, capped at
+ * SEARCH_ENGINE_MAX_START_INDEX.
+ */
+export function getSearchIndex(
+  searchParams: ReadonlyURLSearchParams | null
+): number {
+  const value = Number(searchParams?.get(SEARCH_PARAMETERS.START));
+  if (!Number.isInteger(value) || value <= 0) return 0;
+  return Math.min(value, SEARCH_ENGINE_MAX_START_INDEX);
+}
+
+/**
  * Returns search params from the given path.
  * @param asPath - Current path.
  * @returns search params.
@@ -113,22 +142,6 @@ export function hasSearchParamValue(
   parameter: string
 ): boolean {
   return Boolean(getSearchParamValue(searchParams, parameter));
-}
-
-/**
- * Returns category from the current path.
- * @param asPath - Current path.
- * @returns category.
- */
-export function initCategory(asPath: string): SEARCH_CATEGORY | null {
-  const categoryValue = getSearchParamValue(
-    getSearchParams(asPath),
-    SEARCH_PARAMETERS.CATEGORY
-  );
-  if (isCategory(categoryValue)) {
-    return categoryValue;
-  }
-  return null;
 }
 
 /**

--- a/views/SearchView/hooks/common/utils.ts
+++ b/views/SearchView/hooks/common/utils.ts
@@ -4,6 +4,7 @@ import { ReadonlyURLSearchParams } from "next/navigation";
 import { SEARCH_CATEGORY } from "../../common/constants";
 import {
   SEARCH_ENGINE_MAX_START_INDEX,
+  SEARCH_ENGINE_MIN_START_INDEX,
   SEARCH_ENGINE_PARAMETERS,
   SEARCH_ENGINE_PARAMETER_ID,
   SEARCH_ENGINE_PARAMETER_SAFE,
@@ -95,14 +96,16 @@ export function getRequestURL(
  * Returns the search index (start index) encoded in the URL pagination param,
  * clamped to the range the search engine supports.
  * @param searchParams - Search query and category parameters.
- * @returns search index; 0 when the param is absent or invalid, capped at
- * SEARCH_ENGINE_MAX_START_INDEX.
+ * @returns search index; SEARCH_ENGINE_MIN_START_INDEX when the param is absent
+ * or invalid, capped at SEARCH_ENGINE_MAX_START_INDEX.
  */
 export function getSearchIndex(
   searchParams: ReadonlyURLSearchParams | null
 ): number {
   const value = Number(searchParams?.get(SEARCH_PARAMETERS.START));
-  if (!Number.isInteger(value) || value <= 0) return 0;
+  if (!Number.isInteger(value) || value < SEARCH_ENGINE_MIN_START_INDEX) {
+    return SEARCH_ENGINE_MIN_START_INDEX;
+  }
   return Math.min(value, SEARCH_ENGINE_MAX_START_INDEX);
 }
 

--- a/views/SearchView/hooks/useSearch.ts
+++ b/views/SearchView/hooks/useSearch.ts
@@ -1,16 +1,15 @@
 import { CardProps } from "@databiosphere/findable-ui/lib/components/common/Card/card";
 import { useSearchParams } from "next/navigation";
 import { useRouter } from "next/router";
-import { useCallback, useEffect, useState } from "react";
 import { useSiteConfig } from "../../../hooks/useSiteConfig";
 import {
-  OnSearchFn,
   SearchPagination,
   SearchResponse,
   SearchResponseError,
 } from "./common/entities";
 import {
   getRequestURL,
+  getSearchIndex,
   isRequestValid,
   mapSearchPagination,
   mapSearchResults,
@@ -23,40 +22,33 @@ export interface UseSearch {
   isLoading: boolean;
   isSuccess: boolean;
   isValid: boolean;
-  onSearch: OnSearchFn;
   pagination?: SearchPagination;
   results?: CardProps[];
 }
 
 /**
  * Hook facilitating search functionality and results.
+ * Both the search term and the pagination index are derived from the URL, so
+ * refresh, deep-link sharing, and browser back/forward all restore the exact
+ * results page without any local state.
  * @returns search results.
  */
 export const useSearch = (): UseSearch => {
   const { portalURL } = useSiteConfig();
   const { asPath } = useRouter();
-  const [requestURL, setRequestURL] = useState<string>();
+  const searchParams = useSearchParams();
+  const requestURL = getRequestURL(
+    portalURL,
+    searchParams,
+    getSearchIndex(searchParams)
+  );
   const { isIdle, isLoading, isSuccess, response } =
     useFetchSearch<Response>(requestURL);
-  const requestParams = useSearchParams();
-
-  const onSearch = useCallback(
-    ({ searchIndex = 0, searchParams = requestParams }): void => {
-      setRequestURL(getRequestURL(portalURL, searchParams, searchIndex));
-    },
-    [portalURL, requestParams]
-  );
-
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- syncing local requestURL state with URL params; deeper fix is to move searchIndex into the URL — track via #3088
-    onSearch({ searchParams: requestParams });
-  }, [onSearch, requestParams]);
 
   return {
     isLoading: isIdle || isLoading,
     isSuccess: isSuccess,
     isValid: isRequestValid(asPath),
-    onSearch,
     pagination: mapSearchPagination(response),
     results: mapSearchResults(response),
   };

--- a/views/SearchView/hooks/useSearchCategory.ts
+++ b/views/SearchView/hooks/useSearchCategory.ts
@@ -1,9 +1,9 @@
 import { SEARCH_PARAMETERS } from "@databiosphere/findable-ui/lib/components/Layout/components/Header/components/Content/components/Actions/components/Search/components/SearchBar/common/constants";
 import { useSearchParams } from "next/navigation";
 import Router, { useRouter } from "next/router";
-import { useCallback, useState } from "react";
+import { useCallback } from "react";
 import { SEARCH_CATEGORY } from "../common/constants";
-import { initCategory } from "./common/utils";
+import { getCategory } from "./common/utils";
 
 export interface UseSearchCategory {
   category: SEARCH_CATEGORY | null;
@@ -12,16 +12,16 @@ export interface UseSearchCategory {
 
 /**
  * Hook facilitating search functionality; returning search category and category change functionality.
+ * The active category is derived from the URL so it stays in sync on refresh,
+ * deep-link sharing, and browser back/forward.
  * @returns search category and category related functionality.
  */
 export const useSearchCategory = (): UseSearchCategory => {
-  const { asPath, pathname } = useRouter();
+  const { pathname } = useRouter();
   const searchParams = useSearchParams();
-  const [category, setCategory] = useState<SEARCH_CATEGORY | null>(
-    initCategory(asPath)
-  );
+  const category = getCategory(searchParams);
 
-  const onRedirect = useCallback(
+  const onChangeCategory = useCallback(
     (category: SEARCH_CATEGORY | null) => {
       Router.push({
         pathname,
@@ -29,14 +29,6 @@ export const useSearchCategory = (): UseSearchCategory => {
       });
     },
     [pathname, searchParams]
-  );
-
-  const onChangeCategory = useCallback(
-    (category: SEARCH_CATEGORY | null) => {
-      setCategory(category);
-      onRedirect(category);
-    },
-    [onRedirect]
   );
 
   return { category, onChangeCategory };
@@ -58,5 +50,7 @@ function getSearchParams(
   } else {
     params.delete(SEARCH_PARAMETERS.CATEGORY);
   }
+  // Changing category yields a different result set, so reset pagination.
+  params.delete(SEARCH_PARAMETERS.START);
   return params;
 }

--- a/views/SearchView/searchView.styles.ts
+++ b/views/SearchView/searchView.styles.ts
@@ -1,3 +1,4 @@
+import { RoundedPaper } from "@databiosphere/findable-ui/lib/components/common/Paper/components/RoundedPaper/roundedPaper";
 import { PALETTE } from "@databiosphere/findable-ui/lib/styles/common/constants/palette";
 import styled from "@emotion/styled";
 
@@ -19,4 +20,8 @@ export const ViewLayout = styled.div`
       word-break: break-word;
     }
   }
+`;
+
+export const StyledRoundedPaper = styled(RoundedPaper)`
+  overflow: hidden;
 `;

--- a/views/SearchView/searchView.tsx
+++ b/views/SearchView/searchView.tsx
@@ -1,7 +1,7 @@
 import { LoadingIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/LoadingIcon/loadingIcon";
-import { RoundedPaper } from "@databiosphere/findable-ui/lib/components/common/Paper/paper.styles";
 import { Tabs } from "@databiosphere/findable-ui/lib/components/common/Tabs/tabs";
 import { NoResults } from "@databiosphere/findable-ui/lib/components/NoResults/noResults";
+import { useRouter } from "next/router";
 import { Fragment, JSX } from "react";
 import { Heading } from "../../components/common/Typography/components/Heading/heading";
 import { TABS } from "./common/constants";
@@ -9,12 +9,16 @@ import { Pagination } from "./components/Pagination/pagination";
 import { Results } from "./components/Results/results";
 import { useSearch } from "./hooks/useSearch";
 import { useSearchCategory } from "./hooks/useSearchCategory";
-import { ViewLayout } from "./searchView.styles";
+import { StyledRoundedPaper, ViewLayout } from "./searchView.styles";
 
-export const SearchView = (): JSX.Element => {
-  const { isLoading, isSuccess, isValid, onSearch, pagination, results } =
-    useSearch();
+export const SearchView = (): JSX.Element | null => {
+  const { isReady } = useRouter();
+  const { isLoading, isSuccess, isValid, pagination, results } = useSearch();
   const { category, onChangeCategory } = useSearchCategory();
+  // The search page is statically prerendered without URL query params; defer
+  // all URL-driven rendering until the router has hydrated to avoid a hydration
+  // mismatch between the server HTML and the first client render.
+  if (!isReady) return null;
   return (
     <ViewLayout>
       <Heading enableAnchor={false} headingValue="Search" />
@@ -25,12 +29,14 @@ export const SearchView = (): JSX.Element => {
           {isSuccess && (
             <Fragment>
               <Results results={results} />
-              <Pagination onSearch={onSearch} pagination={pagination} />
+              <Pagination pagination={pagination} />
             </Fragment>
           )}
         </Fragment>
       ) : (
-        <NoResults Paper={RoundedPaper} title="Please enter a search term." />
+        <StyledRoundedPaper>
+          <NoResults Paper={null} title="Please enter a search term." />
+        </StyledRoundedPaper>
       )}
     </ViewLayout>
   );


### PR DESCRIPTION
## Summary

Encodes the search pagination index in the URL as a `start` query param, eliminating local pagination state in `SearchView`.

- The search term **and** pagination index are now derived from `useSearchParams()` — refresh, deep-link sharing, and browser back/forward all restore the exact results page. Removes the `react-hooks/set-state-in-effect` suppression.
- The active category tab is derived from the URL too (previously cached in `useState`, so it got stuck on **All** after back/forward), and pagination resets when the category changes.
- New `usePagination` hook pushes the `start` param via `Router.push()` instead of local setters.

## Notes

- **findable-ui bumped to `55.0.0`** for `SEARCH_PARAMETERS.START` and the searchbar's reset-pagination-on-new-query behaviour.
- **Hydration fix:** the search page is statically prerendered without query params, so the view defers URL-driven rendering until `router.isReady` — otherwise the first client render (which reads `window.location`) mismatches the server HTML.
- **Out-of-range `start`:** hand-edited or stale URLs (e.g. `?start=999999`) are clamped to the search engine's last valid page (index 91 — CSE paginates only the first 100 results at 10/page), instead of showing an empty results page.
- Empty-state cards are wrapped so their rounded corners clip content.

Closes #3088
