### PR TITLE
fix: update help email to data-wrangler-team@humancellatlas.org

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -2,6 +2,6 @@ import { Parameter } from "@databiosphere/findable-ui/lib/utils/replaceParameter
 
 export const PARAMETERS: Parameter = {
   emailHcaSlack: "mailto:slack@humancellatlas.org",
-  emailHelp: "mailto:wrangler-team@data.humancellatlas.org",
+  emailHelp: "mailto:data-wrangler-team@humancellatlas.org",
   hcaOrg: "https://www.humancellatlas.org",
 };

--- a/docs/contact.mdx
+++ b/docs/contact.mdx
@@ -10,7 +10,7 @@ We are constantly improving the Data Portal to be a better resource for our comm
 
 ## Email us with questions
 
-Find something that’s not working right? Have questions about the Data Portal or the datasets? Email us at [wrangler-team@data.humancellatlas.org]({emailHelp}) to ask questions or report issues.
+Find something that’s not working right? Have questions about the Data Portal or the datasets? Email us at [data-wrangler-team@humancellatlas.org]({emailHelp}) to ask questions or report issues.
 
 ## Register with the HCA
 

--- a/docs/contribute/submitting-fastqs-and-tier-2-metadata-to-the-hca-data-repository.mdx
+++ b/docs/contribute/submitting-fastqs-and-tier-2-metadata-to-the-hca-data-repository.mdx
@@ -51,4 +51,4 @@ To submit raw data (FASTQ files) and Tier 2 metadata, please follow the process 
 
 3. Data contributors will then be sent a metadata template to complete and credentials to securely upload the Tier 2 metadata and FASTQ files to the HCA Data Repository.
 
-If a contributor wishes to publish their embargoed dataset at an earlier date they can do so by contacting the wrangling team at [wrangler-team@data.humancellatlas.org](mailto:wrangler-team@data.humancellatlas.org). 
+If a contributor wishes to publish their embargoed dataset at an earlier date they can do so by contacting the wrangling team at [data-wrangler-team@humancellatlas.org](mailto:data-wrangler-team@humancellatlas.org). 

--- a/docs/guides/requesting-access-to-controlled-access-data.mdx
+++ b/docs/guides/requesting-access-to-controlled-access-data.mdx
@@ -81,7 +81,7 @@ The Datasets section of the Data Portal provides an interactive Data Explorer. P
 
    d. Click the blue **Attest** button and submit.
 
-   e. If you do not hear from the HCA DAC within two weeks, please contact HCA support at [wrangler-team@data.humancellatlas.org]({emailHelp}).
+   e. If you do not hear from the HCA DAC within two weeks, please contact HCA support at [data-wrangler-team@humancellatlas.org]({emailHelp}).
 
 ![Attest](/hca-bio-networks/guides/attest.png)
 

--- a/docs/help.mdx
+++ b/docs/help.mdx
@@ -1,12 +1,12 @@
 ---
 date: "2018-05-03"
-description: "If you have questions or issues to report please email wrangler-team@data.humancellatlas.org."
+description: "If you have questions or issues to report please email data-wrangler-team@humancellatlas.org."
 title: "Get Help"
 ---
 
 # Get Help
 
-If you have questions or issues to report please email [wrangler-team@data.humancellatlas.org]({emailHelp}).
+If you have questions or issues to report please email [data-wrangler-team@humancellatlas.org]({emailHelp}).
 
 ## Join the Data Portal slack community
 
@@ -67,4 +67,4 @@ Visit the _Contact_ page to learn how to collaborate with us and to reach us wit
 
 #### How can I reuse parts of the HCA Data Portal?
 
-One of our goals is to make the HCA Data Portal code open and reusable to the community. For now, contact us at [wrangler-team@data.humancellatlas.org]({emailHelp}) with questions about reusing our code. Stay tuned for more information about reusing code in the _Intro_ section of the _Data Portal_.
+One of our goals is to make the HCA Data Portal code open and reusable to the community. For now, contact us at [data-wrangler-team@humancellatlas.org]({emailHelp}) with questions about reusing our code. Stay tuned for more information about reusing code in the _Intro_ section of the _Data Portal_.

--- a/docs/privacy.mdx
+++ b/docs/privacy.mdx
@@ -114,7 +114,7 @@ You may choose not to visit or use or participate in HCA Data Portal Services. I
 
 ### Questions and Complaints
 
-If you have questions or complaints about our treatment of your Personal Data, or have a request to delete your data, please feel free to contact [wrangler-team@data.humancellatlas.org]({emailHelp}).\
+If you have questions or complaints about our treatment of your Personal Data, or have a request to delete your data, please feel free to contact [data-wrangler-team@humancellatlas.org]({emailHelp}).\
 Effective Date: This statement is effective as of July 12, 2022.
 
 ## Privacy Notice for Human Cell Atlas Data Portal Public Website for Individuals outside of the European Economic Area
@@ -206,5 +206,5 @@ You may choose not to visit or use or participate in HCA Data Portal Services. I
 
 ### Questions and Complaints
 
-If you have questions or complaints about our treatment of your Personal Data, or have a request to delete your data, please feel free to contact [wrangler-team@data.humancellatlas.org]({emailHelp}).\
+If you have questions or complaints about our treatment of your Personal Data, or have a request to delete your data, please feel free to contact [data-wrangler-team@humancellatlas.org]({emailHelp}).\
 Effective Date: This statement is effective as of July 12, 2022.


### PR DESCRIPTION
## Ticket
Closes #3127

## Summary
- Updated help/support email from `wrangler-team@data.humancellatlas.org` to `data-wrangler-team@humancellatlas.org` across all references
- Also updated the hardcoded mailto link in the contribute docs to use the new email

## Test plan
- [ ] Verify email link on `/help`, `/contact`, `/privacy`, `/guides/requesting-access-to-controlled-access-data`, and `/contribute/submitting-fastqs-and-tier-2-metadata-to-the-hca-data-repository` points to `data-wrangler-team@humancellatlas.org`

🤖 Generated with [Claude Code](https://claude.com/claude-code)