### PR TITLE
ci: group dependabot updates into monthly PRs #3143

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,29 @@ updates:
   - package-ecosystem: "npm"
     # Look for `package.json` and `lock` files in the `root` directory
     directory: "/"
-    # Check the npm registry for updates every day (weekdays)
+    # Check the npm registry for updates monthly, grouping minor and patch
+    # bumps into a single PR; major bumps still open individual PRs
     schedule:
-      interval: "daily"
+      interval: "monthly"
     assignees:
-      - "noopdog"
-    open-pull-requests-limit: 50
+      - "NoopDog"
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+  # Enable version updates for the analytics Python scripts, grouping all
+  # bumps into a single PR per run
+  - package-ecosystem: "pip"
+    directory: "/analytics"
+    schedule:
+      interval: "monthly"
+    assignees:
+      - "NoopDog"
+    groups:
+      all-updates:
+        patterns:
+          - "*"


### PR DESCRIPTION
Closes #3143

Mirrors the config adopted in anvilproject/anvil-portal#3999 / anvilproject/anvil-portal#4017 / anvilproject/anvil-portal#4026:

- **npm**: daily → monthly schedule; minor and patch bumps grouped into a single PR (majors still open individually); `open-pull-requests-limit` lowered from 50 to 5
- **pip**: new monthly entry for `/analytics` with all updates grouped into one PR (its 13 open security PRs currently arrive per-package)
- **assignees**: `noopdog` → `NoopDog` — Dependabot validates assignees case-sensitively and errors on every PR with the lowercase spelling

On its next run Dependabot should reconcile the 23 open per-package npm PRs into grouped ones. A follow-up PR will refresh `analytics/requirements.txt` to close out the pip security PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)