### PR TITLE
feat: add breast atlas v1 (ihbca v1) to hca data portal (#3149)

### DIFF
--- a/@types/network.ts
+++ b/@types/network.ts
@@ -181,6 +181,7 @@ export type NetworkKey =
 
 export type AtlasKey =
   | "brain-v1-0"
+  | "breast-v1"
   | "cortex-v1-0"
   | "gut-v1-0"
   | "lung-v1-0"

--- a/@types/network.ts
+++ b/@types/network.ts
@@ -35,6 +35,7 @@ export interface Publication {
 }
 
 export interface Atlas {
+  bioTuring?: boolean; // Displays the BioTuring collection link under "Data Exploration Tools".
   code?: Pick<LinkProps, "label" | "url">[];
   componentAtlases?: IntegratedAtlas[]; // "external" integrated atlases.
   contact?: Contact;

--- a/components/HCABioNetworks/Network/Atlas/components/Overview/components/SideColumn/sideColumn.tsx
+++ b/components/HCABioNetworks/Network/Atlas/components/Overview/components/SideColumn/sideColumn.tsx
@@ -6,9 +6,7 @@ import { HCABiologicalNetwork } from "../../../../../../../common/Section/compon
 import { Publications } from "../../../../../../../common/Section/components/Publications/publications";
 import { References } from "../../../../../../../common/Section/components/References/references";
 import { DataReleasePolicy } from "../../../common/DataReleasePolicy/dataReleasePolicy";
-
-const BIOTURING_URL =
-  "https://talk2data.bioturing.com/?tab=studies&version_id=hca&params=N4IgbgpgTgzglgewHYgFwgBYGMCGIC%2BQA";
+import { getDataExplorationTools } from "./utils";
 
 export const SideColumn = (): JSX.Element => {
   const { atlas, network } = useAtlas();
@@ -16,11 +14,11 @@ export const SideColumn = (): JSX.Element => {
     code,
     contact: atlasContact,
     coordinators: atlasCoordinators,
-    cxgDataPortal = [],
     publications,
   } = atlas;
   const { contact: networkContact, coordinators: networkCoordinators } =
     network;
+  const references = getDataExplorationTools(atlas);
   return (
     <Fragment>
       <Sections>
@@ -31,13 +29,9 @@ export const SideColumn = (): JSX.Element => {
         {/* Code */}
         {code && <References links={code} title="Code" />}
         {/* Data Exploration Tools */}
-        <References
-          links={[
-            ...cxgDataPortal,
-            { label: "BioTuring Collection", url: BIOTURING_URL },
-          ]}
-          title="Data Exploration Tools"
-        />
+        {references.length > 0 && (
+          <References links={references} title="Data Exploration Tools" />
+        )}
         {/* Atlas Coordinators */}
         <Coordinators
           coordinators={atlasCoordinators}

--- a/components/HCABioNetworks/Network/Atlas/components/Overview/components/SideColumn/utils.ts
+++ b/components/HCABioNetworks/Network/Atlas/components/Overview/components/SideColumn/utils.ts
@@ -1,0 +1,25 @@
+import type { LinkProps } from "@databiosphere/findable-ui/lib/components/Links/components/Link/link";
+import type { Atlas } from "../../../../../../../../@types/network";
+
+const BIOTURING_URL =
+  "https://talk2data.bioturing.com/?tab=studies&version_id=hca&params=N4IgbgpgTgzglgewHYgFwgBYGMCGIC%2BQA";
+
+/**
+ * Returns the "Data Exploration Tools" links for an atlas: the CELLxGENE data
+ * portal links, followed by the BioTuring collection for atlases opted in with
+ * the `bioTuring` flag.
+ * @param atlas - Atlas.
+ * @returns data exploration tool links.
+ */
+export function getDataExplorationTools(
+  atlas: Atlas
+): Pick<LinkProps, "label" | "url">[] {
+  const { bioTuring, cxgDataPortal = [] } = atlas;
+
+  if (!bioTuring) return cxgDataPortal;
+
+  return [
+    ...cxgDataPortal,
+    { label: "BioTuring Collection", url: BIOTURING_URL },
+  ];
+}

--- a/constants/networks.ts
+++ b/constants/networks.ts
@@ -7,6 +7,7 @@ import {
 } from "../@types/network";
 import * as adiposeContent from "../content/adipose";
 import * as breastContent from "../content/breast";
+import * as breastNetworkBreastAtlas from "../content/breast/atlases/breast";
 import * as developmentContent from "../content/development";
 import * as eyeContent from "../content/eye";
 import * as eyeNetworkRetinaAtlas from "../content/eye/atlases/retina";
@@ -35,6 +36,7 @@ import { COMPONENT_ATLASES } from "./componentAtlases";
 import { DATASETS } from "./datasets";
 
 const BRAIN_V1_0 = "brain-v1-0";
+const BREAST_V1 = "breast-v1";
 const CORTEX_V1_0 = "cortex-v1-0";
 const GUT_V1_0 = "gut-v1-0";
 const LUNG_V1_0 = "lung-v1-0";
@@ -52,7 +54,35 @@ export const NETWORKS: Network[] = [
     path: "adipose",
   },
   {
-    atlases: [],
+    atlases: [
+      {
+        code: [
+          {
+            label: "https://github.com/NoahWex/iHBCAv1_upload",
+            url: "https://github.com/NoahWex/iHBCAv1_upload",
+          },
+        ],
+        coordinators: [
+          { email: "nwechter@uci.edu", fullName: "Noah Wechter" },
+          { email: "prabhakg@uci.edu", fullName: "Gautham Prabhakar" },
+          { email: "adr44@cam.ac.uk", fullName: "Austin Reed" },
+        ],
+        datasets: [],
+        externalDatasets: [],
+        integratedAtlases: [],
+        key: BREAST_V1,
+        name: "Integrated Human Breast Cell Atlas (iHBCA) v1",
+        path: BREAST_V1,
+        publications: [],
+        summaryCellCount: 2128505,
+        tracker: {
+          shortNameSlug: "breast",
+          version: "v1",
+        },
+        updatedAt: "",
+        version: "v1",
+      },
+    ],
     contact: { email: "breast@humancellatlas.org" },
     coordinators: [
       { fullName: "Kai Kessenbrock" },
@@ -565,6 +595,9 @@ export const NETWORK_ICONS: { [key in NetworkKey]: string } = {
 export const NETWORK_ATLAS_CONTENT: Partial<
   Record<NetworkKey, { [key in AtlasKey]?: AtlasModule }>
 > = {
+  breast: {
+    [BREAST_V1]: breastNetworkBreastAtlas,
+  },
   eye: { [RETINA_V1_0]: eyeNetworkRetinaAtlas },
   gut: {
     [GUT_V1_0]: gutNetworkGutAtlas,

--- a/constants/networks.ts
+++ b/constants/networks.ts
@@ -113,6 +113,7 @@ export const NETWORKS: Network[] = [
   {
     atlases: [
       {
+        bioTuring: true,
         code: [
           {
             label: "https://github.com/RCHENLAB/HRCA_reproducibility",
@@ -252,6 +253,7 @@ export const NETWORKS: Network[] = [
   {
     atlases: [
       {
+        bioTuring: true,
         code: [
           {
             label: "https://github.com/LungCellAtlas/HLCA",
@@ -345,6 +347,7 @@ export const NETWORKS: Network[] = [
     BICCNPublications: BICCN_PUBLICATIONS.NERVOUS_SYSTEM,
     atlases: [
       {
+        bioTuring: true,
         code: [
           {
             label: "https://github.com/linnarsson-lab/adult-human-brain",
@@ -373,6 +376,7 @@ export const NETWORKS: Network[] = [
         version: "v1",
       },
       {
+        bioTuring: true,
         code: [
           {
             label: "https://github.com/AllenInstitute/human_cross_areal",
@@ -422,6 +426,7 @@ export const NETWORKS: Network[] = [
   {
     atlases: [
       {
+        bioTuring: true,
         code: [
           {
             label: "https://github.com/theislab/neural_organoid_atlas",
@@ -465,6 +470,7 @@ export const NETWORKS: Network[] = [
         version: "v1",
       },
       {
+        bioTuring: true,
         code: [
           {
             label: "https://github.com/devsystemslab/HEOCA",

--- a/constants/networks.ts
+++ b/constants/networks.ts
@@ -58,22 +58,27 @@ export const NETWORKS: Network[] = [
       {
         code: [
           {
-            label: "https://github.com/NoahWex/iHBCAv1_upload",
-            url: "https://github.com/NoahWex/iHBCAv1_upload",
+            label: "https://github.com/NoahWex/iHBCA_v1",
+            url: "https://github.com/NoahWex/iHBCA_v1",
           },
         ],
         coordinators: [
           { email: "nwechter@uci.edu", fullName: "Noah Wechter" },
-          { email: "prabhakg@uci.edu", fullName: "Gautham Prabhakar" },
           { email: "adr44@cam.ac.uk", fullName: "Austin Reed" },
+          { email: "prabhakg@uci.edu", fullName: "Gautham Prabhakar" },
         ],
         datasets: [],
         externalDatasets: [],
         integratedAtlases: [],
         key: BREAST_V1,
-        name: "Integrated Human Breast Cell Atlas (iHBCA) v1",
+        name: "integrated Human Breast Cell Atlas (iHBCA) v1",
         path: BREAST_V1,
-        publications: [],
+        publications: [
+          {
+            doi: "https://doi.org/10.1038/s41588-024-01688-9",
+            label: "Reed et al. (2024) Nat Genet",
+          },
+        ],
         summaryCellCount: 2128505,
         tracker: {
           shortNameSlug: "breast",

--- a/constants/networks.ts
+++ b/constants/networks.ts
@@ -82,7 +82,7 @@ export const NETWORKS: Network[] = [
         summaryCellCount: 2128505,
         tracker: {
           shortNameSlug: "breast",
-          version: "v1",
+          version: "v1.0",
         },
         updatedAt: "",
         version: "v1",

--- a/content/breast/atlases/breast/index.ts
+++ b/content/breast/atlases/breast/index.ts
@@ -1,0 +1,3 @@
+import Description from "./v1/description.mdx";
+
+export { Description };

--- a/content/breast/atlases/breast/v1/description.mdx
+++ b/content/breast/atlases/breast/v1/description.mdx
@@ -1,7 +1,22 @@
-An optimized, integrated Human Breast Cell Atlas: a cross-study single-cell reference of the adult human breast that harmonizes 2,128,505 cells from 287 donors across seven independently generated studies into a single latent space.
+### Highlights
 
-The atlas uses deep generative modelling (scVI) to reduce batch effects while preserving biological variation, and provides 11 major cell lineage annotations harmonized across all contributing studies. Donor metadata is harmonized across biological covariates (age, parity, menopausal status, BRCA1/2 status, cancer history, BMI) and technical covariates (study, sample, enrichment, dissociation protocol).
+- Harmonizes 2,128,505 cells from 287 donors across seven independently generated studies into a single integrated latent space (scVI).
+- Annotated at the level of 11 major cell lineages, consistent across all seven contributing studies.
+- Extensively harmonized donor metadata (age, parity, menopausal status, BRCA1/2 genotype, cancer history, BMI) plus technical covariates.
+- Provided as a reusable cross-study reference enabling analysis on a common embedding.
+
+### Overview
+
+iHBCA v1 is an optimized, integrated Human Breast Cell Atlas: a cross-study single-cell reference of the adult human breast that harmonizes 2,128,505 cells from 287 donors across seven independently generated studies into a single latent space. Using a deep generative model (scVI), cross-study batch effects are reduced while preserving biological variation, placing all contributing studies in one analyzable embedding annotated at the level of 11 major cell lineages.
+
+The atlas carries extensively harmonized donor metadata spanning biological covariates (age, parity, menopausal status, BRCA1/2 germline status, cancer history, BMI) and technical covariates (study, sample, enrichment, dissociation protocol). iHBCA v1 is provided as a reusable community reference enabling cross-study analysis on a common embedding.
+
+### Impact
+
+- Places seven independently generated breast studies in one analyzable latent space for direct cross-study comparison.
+- Harmonized biological and technical metadata support covariate-aware analysis across the pooled cohort.
+- A reusable community reference foundation for the adult human breast, extensible with finer annotation.
 
 ### Integrated Objects
 
-The integrated objects for this atlas are sourced from the HCA Atlas Tracker. Per-object descriptions will be added with input from the integration leads.
+**iHBCA v1.0** — The integrated Human Breast Cell Atlas (iHBCA) v1.0 is a cross-study reference of the non-tumor adult human breast, harmonizing 2,128,505 cells from 287 donors across seven published single-cell RNA-seq studies. It builds on the atlas first introduced in Reed et al. 2024, with a re-optimized integration (scVI), harmonized donor metadata, and cell-type annotation mapped to consensus nomenclature across three broad lineages and 11 major cell-type groups. New datasets can be mapped onto it to transfer these labels.

--- a/content/breast/atlases/breast/v1/description.mdx
+++ b/content/breast/atlases/breast/v1/description.mdx
@@ -1,0 +1,7 @@
+An optimized, integrated Human Breast Cell Atlas: a cross-study single-cell reference of the adult human breast that harmonizes 2,128,505 cells from 287 donors across seven independently generated studies into a single latent space.
+
+The atlas uses deep generative modelling (scVI) to reduce batch effects while preserving biological variation, and provides 11 major cell lineage annotations harmonized across all contributing studies. Donor metadata is harmonized across biological covariates (age, parity, menopausal status, BRCA1/2 status, cancer history, BMI) and technical covariates (study, sample, enrichment, dissociation protocol).
+
+### Integrated Objects
+
+The integrated objects for this atlas are sourced from the HCA Atlas Tracker. Per-object descriptions will be added with input from the integration leads.


### PR DESCRIPTION
## Summary

Adds the **integrated Human Breast Cell Atlas (iHBCA) v1** to the HCA Data Portal as a tracker-sourced atlas under the existing **Breast** bio-network, mirroring the Gut v1.0 precedent (#2936). Config + content only — all generic tracker machinery (API client, three-tab page, download URLs, tables) already exists.

**The atlas is now published on the tracker** (`breast` / `v1.0`, published 2026-07-27), so all three tabs build and render: Atlas Overview, Source Studies (7 studies), and Source Datasets (1 integrated object, 2,128,505 cells). This supersedes the earlier "not yet published" note — the screenshots at the bottom show the rendered pages.

Description content is complete, taken verbatim from the [onboarding doc](https://docs.google.com/document/d/1knRUNgDtQrm-LUBsZrm-H-QHNi2DILZzZujI18gQbWc/edit) (see #3164).

### Changes

- `@types/network.ts` — add `"breast-v1"` to the `AtlasKey` union; add optional `bioTuring` flag to `Atlas`.
- `constants/networks.ts` — add the `BREAST_V1` constant and the `Atlas` object in the Breast network, register the MDX in `NETWORK_ATLAS_CONTENT.breast`, and set `bioTuring: true` on the six atlases that have a `cxgId`.
- `content/breast/atlases/breast/index.ts` — export `Description`.
- `content/breast/atlases/breast/v1/description.mdx` — `### Highlights` → `### Overview` → `### Impact` → `### Integrated Objects`.
- `components/HCABioNetworks/.../SideColumn/{sideColumn.tsx,utils.ts}` — render "Data Exploration Tools" only when there is something to show, with the BioTuring link now opt-in per atlas.

### Decisions / assumptions

- **Tracker version is `v1.0`**, confirmed against the published record — `tracker.version` corrected from `"v1"`, which was blocking the page from building at all.
- **Route stays `breast-v1`** even though the tracker version is `v1.0`. This is the only atlas in `networks.ts` not using the `-v1-0` form; renaming to `breast-v1-0` remains an option while nothing is live.
- **Display name** is `integrated Human Breast Cell Atlas (iHBCA) v1` — lowercase `integrated`, matching the doc and the `iHBCA` acronym, consistent with the lung entry's `The integrated Human Lung Cell Atlas (HLCA) v1.0`.
- **One integrated object** is intentional, not an omission — confirmed both by the tracker and by a comment thread in the doc.
- **Publication** — `https://doi.org/10.1038/s41588-024-01688-9` (Reed et al. 2024, Nat Genet), per the doc's Publication DOI field.
- **CELLxGENE omitted** — the doc marks it `[PENDING — staged privately on HCA portal]`, so no `cxgId` is set, and Breast therefore shows no "Data Exploration Tools" section.

### Flags

- **Code link corrected.** The doc gives `https://github.com/NoahWex/iHBCAv1` and this branch originally had `https://github.com/NoahWex/iHBCAv1_upload` — **both 404**. Now points at `https://github.com/NoahWex/iHBCA_v1`, the live repo on Noah Wechter's account. It is a two-commit archive staged for a pending Nature submission and may be renamed when that publishes, so worth re-checking before go-live.
- **Two names for one integrated object.** The tracker titles it "An integrated single-cell breast atlas of 2.1 million cells", while the description's Integrated Objects section calls it `iHBCA v1.0` per the doc. Both appear on the page.
- **The atlas was published on the tracker today**, so the `shortNameSlug` / `version` values are worth re-confirming before merge in case the leads revise the record.
- The download-URL builder produces a flat `.../temp/atlases/{integrated-objects|source-datasets}/{file}` path (no `/breast/breast-v1/` segment) — identical to gut's machinery, but contradicts the URL in the issue. The `temp/atlases/` prefix in the bucket is currently empty (a single zero-byte placeholder key), so neither layout can be confirmed; `S3_BASE_URL` is also shared with gut, so this belongs with whoever owns the ODP upload.

Closes #3149
Closes #3164

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="2407" height="1131" alt="image" src="https://github.com/user-attachments/assets/d86f0173-61bb-4e67-b8e4-6cd7f7edd62d" />

<img width="2410" height="1171" alt="image" src="https://github.com/user-attachments/assets/ea9a956f-8d1b-4ee5-9587-adacd3ebf7cc" />

<img width="2410" height="1133" alt="image" src="https://github.com/user-attachments/assets/9d645449-474c-4f1a-85b5-f052a5bb9f7b" />

<img width="2407" height="1132" alt="image" src="https://github.com/user-attachments/assets/c5710098-9a9c-49ed-bb5d-7886c844b99f" />

<img width="2408" height="1133" alt="image" src="https://github.com/user-attachments/assets/01b1d60a-959d-480e-a2af-0f18781ac91a" />
