### PR TITLE
ci: pin github actions by commit sha at current versions

### DIFF
--- a/.github/workflows/deploy-analytics.yml
+++ b/.github/workflows/deploy-analytics.yml
@@ -25,16 +25,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: "analytics/site"
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -5,12 +5,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22.13.0"
       - name: Cache npm cache
-        uses: actions/cache@v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}


### PR DESCRIPTION
Closes #3153

Upgrades every action reference in the workflows to its current version and converts all tag pins to commit SHA pins with version comments, exactly per the table in #3153. Each SHA was resolved and verified against the upstream tag. Same change already merged and green in anvilproject/anvil-portal#4040.

## Test plan

- Workflows that trigger on pull requests validate the new pins on this PR itself.
- Workflows that only run on push to the default branch or on dispatch complete a green run after merge, via the next natural trigger or a manual dispatch, with no Node deprecation annotations.
- After the green runs, the allowlist tightening described in #3153 (remove the actions/* wildcard and the GitHub-owned toggle) is applied and the push/dispatch workflows are re-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)