### PR TITLE
feat: re-enable gut atlas v1.0 in hca data portal (undo #3101 hiding) (#3176)

### DIFF
--- a/constants/networks.ts
+++ b/constants/networks.ts
@@ -170,31 +170,37 @@ export const NETWORKS: Network[] = [
     path: "genetic-diversity",
   },
   {
-    atlases: [],
-    // atlases: [
-    //   {
-    //     coordinators: [
-    //       { email: "kkimler@broadinstitute.org", fullName: "Kyle Kimler" },
-    //       {
-    //         email: "christopher.lance@helmholtz-munich.de",
-    //         fullName: "Christopher Lance",
-    //       },
-    //     ],
-    //     datasets: [],
-    //     externalDatasets: [],
-    //     integratedAtlases: [],
-    //     key: GUT_V1_0,
-    //     name: "Human Gut Cell Atlas (HGCA) v1.0",
-    //     path: GUT_V1_0,
-    //     publications: [],
-    //     tracker: {
-    //       shortNameSlug: "gut",
-    //       version: "v1.0",
-    //     },
-    //     updatedAt: "",
-    //     version: "v1",
-    //   },
-    // ],
+    atlases: [
+      {
+        code: [
+          {
+            label:
+              "https://github.com/HCA-integration/hca-gut-atlas-downstream",
+            url: "https://github.com/HCA-integration/hca-gut-atlas-downstream",
+          },
+        ],
+        coordinators: [
+          { email: "kkimler@broadinstitute.org", fullName: "Kyle Kimler" },
+          {
+            email: "christopher.lance@helmholtz-munich.de",
+            fullName: "Christopher Lance",
+          },
+        ],
+        datasets: [],
+        externalDatasets: [],
+        integratedAtlases: [],
+        key: GUT_V1_0,
+        name: "Human Gut Cell Atlas (HGCA) v1.0",
+        path: GUT_V1_0,
+        publications: [],
+        tracker: {
+          shortNameSlug: "gut",
+          version: "v1.0",
+        },
+        updatedAt: "",
+        version: "v1",
+      },
+    ],
     contact: { email: "gut@humancellatlas.org" },
     coordinators: [
       { fullName: "Mike Snyder" },


### PR DESCRIPTION
## Summary

Undoes the hiding applied in #3101, which commented out the entire Gut atlas object because Gut could not be published on the tracker at the time.

Closes #3176

## Changes

`constants/networks.ts` only:

- Uncommented the Gut atlas object in the `gut` network's `atlases` array and removed the `atlases: []` placeholder.
- Added the `code` link for the atlas, matching how the Breast atlas does it: https://github.com/HCA-integration/hca-gut-atlas-downstream

Everything else was already in place and never reverted — the tracker integration (`apis/tracker/api.ts`, build-time fetch, publish gating, source studies / source datasets / integrated objects tabs) from #2936, the column and filter cleanups from #3074 / #3075, and the overview content at `content/gut/atlases/gut/v1.0/description.mdx` wired into `NETWORK_ATLAS_CONTENT`.

## Out of scope

- `summaryCellCount` — not added
- `publications` — stays `[]`, no DOI to link yet
- `bioTuring` — not applicable to Gut
- `site-config/data-portal/dev/.env` — unchanged, still points at the prod tracker

## Tracker state

Gut v1.0 exists on the prod tracker (atlas `4d291476-9ba5-4bd1-8b6d-23f48765e365`) but is **not yet published**:

- `GET /api/published-atlases` returns `[]`
- `GET /api/atlases/4d291476-.../{source-studies,source-datasets,component-atlases}` all return `401`

The same endpoints return `200` with data on the test tracker (7 source studies, 56 source datasets, 13 component atlases).

This is safe to merge ahead of publication. While Gut is unpublished, `isTrackerAtlasPublished` filters it out of `getStaticPaths` and `getAvailableNetworks`, so no atlas page is generated and no tracker fetch occurs. The atlas surfaces automatically once the tracker publishes — no further portal change needed.

## Verification

Against the **prod** tracker (Gut unpublished):

- `npm run build-dev:data-portal` succeeds; no Gut atlas page is generated
- Gut Network page renders with "Gut Network atlases are still under development."
- Bio-networks atlases table lists Gut with `0`
- Bio-networks grid shows Gut with no atlas count badge

Against the **test** tracker (Gut published), all three routes generate and render correctly:

- `/hca-bio-networks/gut/atlases/gut-v1-0`
- `/hca-bio-networks/gut/atlases/gut-v1-0/datasets`
- `/hca-bio-networks/gut/atlases/gut-v1-0/source-studies`

Rendered output confirmed to include the atlas name, description content, integrated object entries, the new code repo link, and hyperlinked integration lead emails.

Also run: `npx tsc --noEmit` (clean), `eslint` (0 errors), `prettier --check .` (clean).

## Note for reviewers

On `main`, `sideColumn.tsx` renders the BioTuring Collection link **unconditionally** for every atlas, so Gut currently shows one. The `bioTuring` opt-in flag that gates this lives in #3149 (`fran/3149-add-breast-atlas-v1`), which is not yet merged. Once #3149 lands, Gut has no `bioTuring` flag and the link correctly disappears — no change needed here. Merging #3149 first avoids Gut briefly advertising a BioTuring collection it isn't part of.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
