### PR TITLE
feat: add liver atlas v1.0 to hca data portal (#3175)

### DIFF
--- a/@types/network.ts
+++ b/@types/network.ts
@@ -36,6 +36,7 @@ export interface Publication {
 
 export interface Atlas {
   bioTuring?: boolean; // Displays the BioTuring collection link under "Data Exploration Tools".
+  cellBrowser?: Pick<LinkProps, "label" | "url">[]; // Additional "Data Exploration Tools" links, e.g. UCSC Cell Browser.
   code?: Pick<LinkProps, "label" | "url">[];
   componentAtlases?: IntegratedAtlas[]; // "external" integrated atlases.
   contact?: Contact;

--- a/@types/network.ts
+++ b/@types/network.ts
@@ -185,6 +185,7 @@ export type AtlasKey =
   | "breast-v1"
   | "cortex-v1-0"
   | "gut-v1-0"
+  | "liver-v1-0"
   | "lung-v1-0"
   | "organoid-endoderm-v1-0"
   | "organoid-neural-v1-0"

--- a/components/HCABioNetworks/Network/Atlas/components/Overview/components/SideColumn/utils.ts
+++ b/components/HCABioNetworks/Network/Atlas/components/Overview/components/SideColumn/utils.ts
@@ -6,20 +6,19 @@ const BIOTURING_URL =
 
 /**
  * Returns the "Data Exploration Tools" links for an atlas: the CELLxGENE data
- * portal links, followed by the BioTuring collection for atlases opted in with
- * the `bioTuring` flag.
+ * portal links, followed by any cell browser links, followed by the BioTuring
+ * collection for atlases opted in with the `bioTuring` flag.
  * @param atlas - Atlas.
  * @returns data exploration tool links.
  */
 export function getDataExplorationTools(
   atlas: Atlas
 ): Pick<LinkProps, "label" | "url">[] {
-  const { bioTuring, cxgDataPortal = [] } = atlas;
+  const { bioTuring, cellBrowser = [], cxgDataPortal = [] } = atlas;
 
-  if (!bioTuring) return cxgDataPortal;
+  const links = [...cxgDataPortal, ...cellBrowser];
 
-  return [
-    ...cxgDataPortal,
-    { label: "BioTuring Collection", url: BIOTURING_URL },
-  ];
+  if (!bioTuring) return links;
+
+  return [...links, { label: "BioTuring Collection", url: BIOTURING_URL }];
 }

--- a/constants/networks.ts
+++ b/constants/networks.ts
@@ -195,6 +195,7 @@ export const NETWORKS: Network[] = [
         name: "Human Gut Cell Atlas (HGCA) v1.0",
         path: GUT_V1_0,
         publications: [],
+        summaryCellCount: 944502, // "All Cells" component atlas cell count; the lineage objects are subsets of it.
         tracker: {
           shortNameSlug: "gut",
           version: "v1.0",

--- a/constants/networks.ts
+++ b/constants/networks.ts
@@ -18,6 +18,7 @@ import * as heartContent from "../content/heart";
 import * as immuneContent from "../content/immune";
 import * as kidneyContent from "../content/kidney";
 import * as liverContent from "../content/liver";
+import * as liverNetworkLiverAtlas from "../content/liver/atlases/liver";
 import * as lungContent from "../content/lung";
 import * as lungNetworkLungAtlas from "../content/lung/atlases/lung";
 import * as musculoskeletalContent from "../content/musculoskeletal";
@@ -39,6 +40,7 @@ const BRAIN_V1_0 = "brain-v1-0";
 const BREAST_V1 = "breast-v1";
 const CORTEX_V1_0 = "cortex-v1-0";
 const GUT_V1_0 = "gut-v1-0";
+const LIVER_V1_0 = "liver-v1-0";
 const LUNG_V1_0 = "lung-v1-0";
 const ORGANOID_ENDODERM_V1_0 = "organoid-endoderm-v1-0";
 const ORGANOID_NEURAL_V1_0 = "organoid-neural-v1-0";
@@ -249,7 +251,40 @@ export const NETWORKS: Network[] = [
     path: "kidney",
   },
   {
-    atlases: [],
+    atlases: [
+      {
+        code: [
+          {
+            label: "https://github.com/quon-titative-biology/HLiCA",
+            url: "https://github.com/quon-titative-biology/HLiCA",
+          },
+        ],
+        coordinators: [
+          { email: "r.edgar@utoronto.ca", fullName: "Rachel Edgar" },
+          { email: "gquon@ucdavis.edu", fullName: "Gerald Quon" },
+          { email: "gary.bader@utoronto.ca", fullName: "Gary Bader" },
+        ],
+        datasets: [],
+        externalDatasets: [],
+        integratedAtlases: [],
+        key: LIVER_V1_0,
+        name: "Human Liver Cell Atlas (HLiCA) v1.0",
+        path: LIVER_V1_0,
+        publications: [
+          {
+            doi: "https://doi.org/10.64898/2026.06.30.735539",
+            label: "Edgar et al. (2026) bioRxiv",
+          },
+        ],
+        summaryCellCount: 524699, // "All cells" CXG dataset cell count; the lineage objects are subsets of it.
+        tracker: {
+          shortNameSlug: "liver",
+          version: "v1.0",
+        },
+        updatedAt: "",
+        version: "v1",
+      },
+    ],
     contact: { email: "liver@humancellatlas.org" },
     coordinators: [{ fullName: "Gary Bader" }, { fullName: "Alan Mullen" }],
     key: "liver",
@@ -618,6 +653,9 @@ export const NETWORK_ATLAS_CONTENT: Partial<
   eye: { [RETINA_V1_0]: eyeNetworkRetinaAtlas },
   gut: {
     [GUT_V1_0]: gutNetworkGutAtlas,
+  },
+  liver: {
+    [LIVER_V1_0]: liverNetworkLiverAtlas,
   },
   lung: {
     [LUNG_V1_0]: lungNetworkLungAtlas,

--- a/constants/networks.ts
+++ b/constants/networks.ts
@@ -253,6 +253,12 @@ export const NETWORKS: Network[] = [
   {
     atlases: [
       {
+        cellBrowser: [
+          {
+            label: "UCSC Cell Browser",
+            url: "https://human-liver-cell-atlas.cells.ucsc.edu",
+          },
+        ],
         code: [
           {
             label: "https://github.com/quon-titative-biology/HLiCA",
@@ -264,6 +270,7 @@ export const NETWORKS: Network[] = [
           { email: "gquon@ucdavis.edu", fullName: "Gerald Quon" },
           { email: "gary.bader@utoronto.ca", fullName: "Gary Bader" },
         ],
+        cxgId: "059202e1-1f1b-483f-9151-f3a25a380c39",
         datasets: [],
         externalDatasets: [],
         integratedAtlases: [],

--- a/content/liver/atlases/liver/index.ts
+++ b/content/liver/atlases/liver/index.ts
@@ -1,0 +1,3 @@
+import Description from "./v1.0/description.mdx";
+
+export { Description };

--- a/content/liver/atlases/liver/v1.0/description.mdx
+++ b/content/liver/atlases/liver/v1.0/description.mdx
@@ -1,0 +1,28 @@
+### Highlights
+
+- Largest human liver cell atlas to date, integrating data from 110 donors and over 520,000 cells, with 47 distinct cell types annotated.
+- Comprehensive benchmarking was done with four integration methods across three metrics, ensuring robustness against technical variability (e.g., research center, cell suspension).
+- Collaborative cell annotation refinement incorporated feedback from experts across the field through focused annotation meetings to resolve key classification challenges.
+- Novel cell types identified in the atlas were validated using spatial transcriptomics to confirm their anatomical context.
+
+### Overview
+
+The Human Liver Cell Atlas (HLiCA) is an integrated reference of non-disease liver cells assembled from eight datasets across six research centers, encompassing more than 525,000 cells from 110 donors. Developed in collaboration with the Human Cell Atlas Liver Bionetwork, the HLiCA incorporates expert-curated cell annotations refined through community feedback and dedicated cell type annotation meetings. The HLiCA classifies cells into six lineages and expands the cell type resolution to include 47 distinct cell types. Starting from raw sequencing reads, we realigned all data and performed rigorous benchmarking to ensure robust integration across technical and biological variables. Genetic ancestry was inferred for all samples to evaluate the range of ancestral backgrounds represented in the atlas.
+
+As the largest and most genetically diverse human liver cell atlas to date, the HLiCA provides a comprehensive, well-annotated reference for the field, annotated by expert consensus. This resource will enable deeper interrogation of liver cellular diversity, architecture, and function in the healthy human liver and serve as a reference to understand changes that occur with disease.
+
+### Integrated Objects
+
+**Human liver cell atlas - all cells** — A total of 47 liver cell types were identified from over 520,000 cells in the current atlas.
+
+**Human liver cell atlas - cholangiocyte cells** — Epithelial cells lining the bile ducts, involved in bile production and modification.
+
+**Human liver cell atlas - mesenchyme cells** — Structural and supportive cells including fibroblasts and stellate cells, contributing to liver architecture.
+
+**Human liver cell atlas - myeloid cells** — Innate immune cells including macrophages and dendritic cells, key in tissue homeostasis and immune surveillance.
+
+**Human liver cell atlas - lymphocyte cells** — Adaptive immune cells such as T cells, B cells, and NK cells, involved in immune regulation and response.
+
+**Human liver cell atlas - endothelia cells** — Cells lining the liver vasculature, including liver sinusoidal endothelial cells, regulating filtration and cell trafficking.
+
+**Human liver cell atlas - hepatocyte cells** — The main parenchymal liver cells responsible for metabolism, detoxification, and protein synthesis.

--- a/content/liver/atlases/liver/v1.0/description.mdx
+++ b/content/liver/atlases/liver/v1.0/description.mdx
@@ -23,6 +23,6 @@ As the largest and most genetically diverse human liver cell atlas to date, the 
 
 **Human liver cell atlas - lymphocyte cells** — Adaptive immune cells such as T cells, B cells, and NK cells, involved in immune regulation and response.
 
-**Human liver cell atlas - endothelia cells** — Cells lining the liver vasculature, including liver sinusoidal endothelial cells, regulating filtration and cell trafficking.
+**Human liver cell atlas - endothelial cells** — Cells lining the liver vasculature, including liver sinusoidal endothelial cells, regulating filtration and cell trafficking.
 
 **Human liver cell atlas - hepatocyte cells** — The main parenchymal liver cells responsible for metabolism, detoxification, and protein synthesis.

--- a/utils/network.ts
+++ b/utils/network.ts
@@ -24,8 +24,8 @@ function buildCXGAnalysisPortal(cxgURL: string): AnalysisPortal {
 }
 
 /**
- * Builds the CELLxGENE data portal link for the given CELLxGENE dataset ID.
- * @param cxgId - CELLxGENE dataset ID.
+ * Builds the CELLxGENE data portal link for the given CELLxGENE collection ID.
+ * @param cxgId - CELLxGENE collection ID.
  * @returns CELLxGENE data portal link.
  */
 export function buildCXGDataPortalLink(

--- a/utils/network.ts
+++ b/utils/network.ts
@@ -28,7 +28,7 @@ function buildCXGAnalysisPortal(cxgURL: string): AnalysisPortal {
  * @param cxgId - CELLxGENE dataset ID.
  * @returns CELLxGENE data portal link.
  */
-function buildCXGDataPortalLink(
+export function buildCXGDataPortalLink(
   cxgId: string
 ): Pick<LinkProps, "label" | "url">[] {
   const cxgDataPortalURL = `${CZ_CELLXGENE_DATA_PORTAL_URL}/collections/${cxgId}`;

--- a/utils/trackerAtlasPages.ts
+++ b/utils/trackerAtlasPages.ts
@@ -7,6 +7,7 @@ import {
   resolveTrackerAtlasId,
 } from "../apis/tracker/api";
 import type { StaticProps } from "./atlasPages";
+import { buildCXGDataPortalLink } from "./network";
 import {
   buildTrackerSourceDatasetAsset,
   mapTrackerComponentAtlasToIntegratedAtlas,
@@ -52,6 +53,11 @@ export async function getTrackerContentStaticProps(
 
   const processedAtlas: Atlas = {
     ...atlas,
+    // Only set when the atlas has a CELLxGENE collection; an explicit
+    // `undefined` is not JSON-serializable by `getStaticProps`.
+    ...(atlas.cxgId && {
+      cxgDataPortal: buildCXGDataPortalLink(atlas.cxgId),
+    }),
     integratedAtlases,
     trackerAtlasId: atlasId,
   };


### PR DESCRIPTION
## Summary

Adds the **Human Liver Cell Atlas (HLiCA) v1.0** to the HCA Data Portal as a tracker-sourced atlas under the Liver bio-network, following the Gut v1.0 precedent.

Also corrects the **Gut v1.0 cell count**, which was double-counting — see "Gut cell count" below. That fix is unrelated to the liver work but is a one-line change to the same file, so it rides along here.

Closes #3175

## Changes

**Liver atlas**

- `@types/network.ts` — add `liver-v1-0` to the `AtlasKey` union.
- `constants/networks.ts` — add the `Atlas` object to the Liver network (name, path, `tracker: { shortNameSlug: "liver", version: "v1.0" }`, coordinators, publication, code link, `cxgId`) and register the atlas MDX in `NETWORK_ATLAS_CONTENT`.
- `content/liver/atlases/liver/` — `v1.0/description.mdx` (Highlights, Overview, Integrated Objects) plus the `index.ts` export.

**CELLxGENE and Cell Browser links**

- Surface the CELLxGENE collection link under "Data Exploration Tools" for tracker atlases — previously only the non-tracker path built `cxgDataPortal`.
- Add an optional `cellBrowser` field to `Atlas` for additional exploration links, used here for the UCSC Cell Browser.

Liver opts out of BioTuring, so "Data Exploration Tools" renders:

- CZ CELLxGENE Collection
- UCSC Cell Browser

## Notes for review

**Liver cell count.** `summaryCellCount: 524699` is set explicitly. Without it, `rollUpAtlases` sums every integrated object — but "all cells" already contains the six lineage subsets, so the rollup would report 1,048,608 instead of 524,699. The value is the `cell_count` of the `HLiCA - human liver all cells` dataset from the CELLxGENE Discover curation API for collection `059202e1-1f1b-483f-9151-f3a25a380c39`; its DOI and 110-donor count both match the issue. Same approach as Breast v1.

**Gut cell count.** Gut had the same latent bug and is fixed here with `summaryCellCount: 944502`. The tracker's component atlases partition exactly, so the rollup was reporting precisely double:

| Component atlas | Cells |
|---|---|
| HGCA v1 - Lymphoid | 572,267 |
| HGCA v1 - Epithelial | 269,780 |
| HGCA v1 - Stroma | 52,159 |
| HGCA v1 - Myeloid | 50,296 |
| **Lineages subtotal** | **944,502** |
| HGCA v1 - All Cells | 944,502 |
| Rollup total (displayed before this fix) | 1,889,004 |

**Serialization fix.** Building `cxgDataPortal` in `getTrackerContentStaticProps` initially set the key to `undefined` for atlases without a `cxgId`, which broke the Gut datasets page (`undefined` is not JSON-serializable from `getStaticProps`). Now conditionally spread so the key is omitted.

**Gating.** Liver v1.0 is not yet published on the Atlas Tracker — `/api/published-atlases` currently returns Gut v1.0 only. `isTrackerAtlasPublished` therefore skips the liver pages, so nothing renders until the tracker publishes it. This is expected and matches Breast v1.

## Review feedback addressed

- `buildCXGDataPortalLink` JSDoc corrected from "dataset ID" to "collection ID" (`d915e544`).
- `endothelia cells` → `endothelial cells` in the liver Integrated Objects; the other six labels already matched the published CXG dataset titles exactly, so this was a typo (`f21070c0`).

## Verification

- `npx tsc --noEmit` — clean
- `eslint` / `prettier` — clean on changed files (remaining warnings are pre-existing)
- `npm run build-dev:data-portal` — succeeds, 65/65 static pages, sitemap generated
- CELLxGENE collection, UCSC Cell Browser, and code repo URLs all return 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)
