### PR TITLE
feat: atlas source datasets table: filter by journal and reference author (#3197)

### DIFF
--- a/@types/network.ts
+++ b/@types/network.ts
@@ -146,7 +146,6 @@ export interface AtlasContext extends NetworkContext {
   atlas: Atlas;
   projectsResponses: ProjectsResponse[];
   trackerSourceDatasets?: TrackerSourceDataset[];
-  trackerSourceStudies?: TrackerSourceStudy[];
 }
 
 export interface NetworkContext {
@@ -229,8 +228,11 @@ export interface TrackerSourceDataset {
   fileId: string;
   fileName: string;
   geneCount: number;
+  hcaProjectId: string | null; // Joined from the source study; null when the study has no HCA project or the join misses.
   id: string;
+  journal: string | null; // Joined from the source study; null when unpublished or the join misses.
   publicationString: string | null;
+  referenceAuthor: string | null; // Joined from the source study; null only when the join misses.
   revision: number;
   sizeBytes: number;
   sourceStudyId: string;

--- a/@types/network.ts
+++ b/@types/network.ts
@@ -241,6 +241,17 @@ export interface TrackerSourceDataset {
   title: string;
 }
 
+/**
+ * A source dataset as the tracker API actually returns it, before
+ * `getTrackerContentStaticProps` adds `datasetAsset` and joins the
+ * source-study fields on. Keeps the fetch signature honest so the joined
+ * fields cannot be read off an unenriched dataset.
+ */
+export type TrackerSourceDatasetResponse = Omit<
+  TrackerSourceDataset,
+  "datasetAsset" | "hcaProjectId" | "journal" | "referenceAuthor"
+>;
+
 export interface TrackerSourceStudy {
   cellxgeneCollectionId: string | null;
   contactEmail: string | null;

--- a/apis/tracker/api.ts
+++ b/apis/tracker/api.ts
@@ -1,6 +1,6 @@
 import type {
   TrackerComponentAtlas,
-  TrackerSourceDataset,
+  TrackerSourceDatasetResponse,
   TrackerSourceStudy,
 } from "../../@types/network";
 import type { PublishedAtlas } from "./types";
@@ -58,7 +58,7 @@ export function fetchTrackerComponentAtlases(
  */
 export function fetchTrackerSourceDatasets(
   atlasId: string
-): Promise<TrackerSourceDataset[]> {
+): Promise<TrackerSourceDatasetResponse[]> {
   return fetchTrackerApi(
     `/api/atlases/${atlasId}/source-datasets`,
     "source datasets"

--- a/components/HCABioNetworks/Network/Atlas/components/Datasets/components/MainColumn/tracker/components/table/accessor.ts
+++ b/components/HCABioNetworks/Network/Atlas/components/Datasets/components/MainColumn/tracker/components/table/accessor.ts
@@ -1,4 +1,9 @@
+import { LABEL } from "@databiosphere/findable-ui/lib/apis/azul/common/entities";
 import type { TrackerSourceDataset } from "../../../../../../../../../../../@types/network";
+
+// Facet value for a source study with no journal, matching the label the
+// removed Source Studies table used.
+const JOURNAL_UNPUBLISHED = "Unpublished";
 
 /**
  * Returns the names of the integrated objects (sourced from the legacy
@@ -8,4 +13,25 @@ import type { TrackerSourceDataset } from "../../../../../../../../../../../@typ
  */
 export function buildIntegratedObjects(row: TrackerSourceDataset): string[] {
   return row.componentAtlases?.map(({ name }) => name) ?? [];
+}
+
+/**
+ * Returns the journal of a source dataset's source study, falling back to
+ * "Unpublished" when the study has no journal (or the build-time join missed).
+ * @param row - Tracker source dataset.
+ * @returns journal name, or "Unpublished".
+ */
+export function buildJournal(row: TrackerSourceDataset): string {
+  return row.journal || JOURNAL_UNPUBLISHED;
+}
+
+/**
+ * Returns the reference author of a source dataset's source study. The tracker
+ * always sets this on a source study, so the fallback covers only a missed
+ * build-time join — hence "Unspecified" rather than "Unpublished".
+ * @param row - Tracker source dataset.
+ * @returns reference author, or "Unspecified".
+ */
+export function buildReferenceAuthor(row: TrackerSourceDataset): string {
+  return row.referenceAuthor || LABEL.UNSPECIFIED;
 }

--- a/components/HCABioNetworks/Network/Atlas/components/Datasets/components/MainColumn/tracker/components/table/columns.ts
+++ b/components/HCABioNetworks/Network/Atlas/components/Datasets/components/MainColumn/tracker/components/table/columns.ts
@@ -10,7 +10,11 @@ import {
   buildPinnedNTagProps,
   renderPinnedNTagCell,
 } from "../../../../../../../../../../common/Table/components/Cell/components/PinnedNTagCell/utils";
-import { buildIntegratedObjects } from "./accessor";
+import {
+  buildIntegratedObjects,
+  buildJournal,
+  buildReferenceAuthor,
+} from "./accessor";
 import {
   renderCellCount,
   renderDownload,
@@ -80,6 +84,22 @@ const INTEGRATED_OBJECTS = {
   id: "integratedObject",
 } as ColumnDef<TrackerSourceDataset>;
 
+const JOURNAL = {
+  accessorFn: buildJournal,
+  enableColumnFilter: true,
+  filterFn: "arrIncludesSome",
+  header: "Journal",
+  id: "journal",
+} as ColumnDef<TrackerSourceDataset>;
+
+const REFERENCE_AUTHOR = {
+  accessorFn: buildReferenceAuthor,
+  enableColumnFilter: true,
+  filterFn: "arrIncludesSome",
+  header: "Reference Author",
+  id: "referenceAuthor",
+} as ColumnDef<TrackerSourceDataset>;
+
 const SOURCE_STUDY = {
   accessorKey: "publicationString",
   cell: renderSourceStudy,
@@ -121,4 +141,6 @@ export const COLUMNS: ColumnDef<TrackerSourceDataset>[] = [
   EXPLORE,
   DOWNLOAD,
   INTEGRATED_OBJECTS,
+  JOURNAL,
+  REFERENCE_AUTHOR,
 ];

--- a/components/HCABioNetworks/Network/Atlas/components/Datasets/components/MainColumn/tracker/components/table/meta.ts
+++ b/components/HCABioNetworks/Network/Atlas/components/Datasets/components/MainColumn/tracker/components/table/meta.ts
@@ -10,6 +10,8 @@ export const META: ColumnFiltersTableMeta<TrackerSourceDataset> = {
         { key: "disease", label: "Disease" },
         { key: "sourceStudy", label: "Source Study" },
         { key: "integratedObject", label: "Integrated Object" },
+        { key: "journal", label: "Journal" },
+        { key: "referenceAuthor", label: "Reference Author" },
       ],
       label: "",
     },

--- a/components/HCABioNetworks/Network/Atlas/components/Datasets/components/MainColumn/tracker/components/table/utils.ts
+++ b/components/HCABioNetworks/Network/Atlas/components/Datasets/components/MainColumn/tracker/components/table/utils.ts
@@ -3,8 +3,9 @@ import type { TrackerSourceDataset } from "../../../../../../../../../../../@typ
 
 /**
  * Returns the column visibility state for the tracker source datasets table.
- * The "Integrated Object" column is filter-only, and the "Explore" column is
- * displayed only when at least one dataset has a CAP link.
+ * The "Integrated Object", "Journal" and "Reference Author" columns are
+ * filter-only, and the "Explore" column is displayed only when at least one
+ * dataset has a CAP link.
  * @param data - Tracker source datasets.
  * @returns column visibility state.
  */
@@ -14,5 +15,7 @@ export function getColumnVisibility(
   return {
     explore: data.some(({ capUrl }) => Boolean(capUrl)),
     integratedObject: false,
+    journal: false,
+    referenceAuthor: false,
   };
 }

--- a/components/common/Filters/components/ColumnFilterTags/columnFilterTags.tsx
+++ b/components/common/Filters/components/ColumnFilterTags/columnFilterTags.tsx
@@ -3,6 +3,7 @@ import { BUTTON_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/b
 import { Button, Theme, useMediaQuery } from "@mui/material";
 import { RowData } from "@tanstack/react-table";
 import { JSX } from "react";
+import { FILTER_DRAWER_BREAKPOINT } from "../../constants";
 import { StyledGrid } from "./columnFilterTags.styles";
 import { GRID_PROPS } from "./constants";
 import { Props } from "./types";
@@ -13,7 +14,7 @@ export const ColumnFilterTags = <T extends RowData>({
   const { getAllColumns, resetColumnFilters } = table;
   const columns = getAllColumns().filter((column) => column.getIsFiltered());
   const isDrawer = useMediaQuery(
-    (theme: Theme) => theme.breakpoints.down(820),
+    (theme: Theme) => theme.breakpoints.down(FILTER_DRAWER_BREAKPOINT),
     { noSsr: true }
   );
 

--- a/components/common/Filters/components/ColumnFilters/columnFilters.tsx
+++ b/components/common/Filters/components/ColumnFilters/columnFilters.tsx
@@ -7,6 +7,7 @@ import { BUTTON_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/b
 import { Theme, useMediaQuery } from "@mui/material";
 import { RowData } from "@tanstack/react-table";
 import { ComponentProps, JSX } from "react";
+import { FILTER_DRAWER_BREAKPOINT } from "../../constants";
 import { StyledButton, StyledButtonGroup } from "./columnFilters.styles";
 import { Props } from "./types";
 import { buildColumnFilters } from "./utils";
@@ -15,7 +16,7 @@ export const ColumnFilters = <T extends RowData>({
   table,
 }: Props<T>): JSX.Element | null => {
   const isDrawer = useMediaQuery(
-    (theme: Theme) => theme.breakpoints.down(820),
+    (theme: Theme) => theme.breakpoints.down(FILTER_DRAWER_BREAKPOINT),
     { noSsr: true }
   );
 

--- a/components/common/Filters/constants.ts
+++ b/components/common/Filters/constants.ts
@@ -1,0 +1,4 @@
+// Viewport width below which column filters collapse from the inline chip row
+// into the filter drawer. Shared by `ColumnFilters` and `ColumnFilterTags` so
+// the chips and their selected-value tags always switch together.
+export const FILTER_DRAWER_BREAKPOINT = 1024;

--- a/contexts/atlasContext.ts
+++ b/contexts/atlasContext.ts
@@ -14,7 +14,6 @@ export const AtlasContext = createContext<AtlasContextType>({
   network: DEFAULT_NETWORK,
   projectsResponses: [],
   trackerSourceDatasets: [],
-  trackerSourceStudies: [],
 });
 
 export const AtlasProvider = AtlasContext.Provider;

--- a/pages/hca-bio-networks/[network]/atlases/[atlas]/datasets.tsx
+++ b/pages/hca-bio-networks/[network]/atlases/[atlas]/datasets.tsx
@@ -29,7 +29,6 @@ const Page = ({
   network,
   projectsResponses,
   trackerSourceDatasets = [],
-  trackerSourceStudies = [],
 }: InferGetStaticPropsType<typeof getStaticProps>): JSX.Element => {
   return (
     <AtlasProvider
@@ -38,7 +37,6 @@ const Page = ({
         network,
         projectsResponses,
         trackerSourceDatasets,
-        trackerSourceStudies,
       }}
     >
       <Detail mainColumn={<MainColumn />} Tabs={<Tabs />} top={<Hero />} />

--- a/pages/hca-bio-networks/[network]/atlases/[atlas]/index.tsx
+++ b/pages/hca-bio-networks/[network]/atlases/[atlas]/index.tsx
@@ -30,7 +30,6 @@ const Page = ({
   network,
   projectsResponses,
   trackerSourceDatasets = [],
-  trackerSourceStudies = [],
 }: InferGetStaticPropsType<typeof getStaticProps>): JSX.Element => {
   return (
     <AtlasProvider
@@ -39,7 +38,6 @@ const Page = ({
         network,
         projectsResponses,
         trackerSourceDatasets,
-        trackerSourceStudies,
       }}
     >
       <Detail

--- a/utils/trackerAtlasPages.ts
+++ b/utils/trackerAtlasPages.ts
@@ -48,10 +48,22 @@ export async function getTrackerContentStaticProps(
     mapTrackerComponentAtlasToIntegratedAtlas
   );
 
-  const trackerSourceDatasets = sourceDatasets.map((sd) => ({
-    ...sd,
-    datasetAsset: buildTrackerSourceDatasetAsset(sd),
-  }));
+  // Journal, reference author and HCA project ID live only on the source study,
+  // so join them onto each source dataset by `sourceStudyId`. A dataset whose
+  // study is missing from the response keeps `null` for all three rather than
+  // being dropped, so a join miss can never hide a dataset from the table.
+  const sourceStudyById = new Map(sourceStudies.map((s) => [s.id, s]));
+
+  const trackerSourceDatasets = sourceDatasets.map((sd) => {
+    const sourceStudy = sourceStudyById.get(sd.sourceStudyId);
+    return {
+      ...sd,
+      datasetAsset: buildTrackerSourceDatasetAsset(sd),
+      hcaProjectId: sourceStudy?.hcaProjectId ?? null,
+      journal: sourceStudy?.journal ?? null,
+      referenceAuthor: sourceStudy?.referenceAuthor ?? null,
+    };
+  });
 
   const cxgDataPortal = buildTrackerCXGDataPortalLink(
     trackerAtlas,
@@ -83,7 +95,6 @@ export async function getTrackerContentStaticProps(
       pageTitle: `${atlas.name} - ${tabName}`,
       projectsResponses: [],
       trackerSourceDatasets,
-      trackerSourceStudies: sourceStudies,
     },
   };
 }

--- a/utils/trackerNetwork.ts
+++ b/utils/trackerNetwork.ts
@@ -4,7 +4,7 @@ import type {
   DatasetAsset,
   IntegratedAtlas,
   TrackerComponentAtlas,
-  TrackerSourceDataset,
+  TrackerSourceDatasetResponse,
 } from "../@types/network";
 import { CXG_DATASET_FILE_TYPE } from "../@types/network";
 import { processNullElements } from "../apis/azul/hca-dcp/common/utils";
@@ -59,7 +59,7 @@ export function buildTrackerCXGDataPortalLink(
  * @returns dataset asset.
  */
 export function buildTrackerSourceDatasetAsset(
-  sourceDataset: TrackerSourceDataset
+  sourceDataset: TrackerSourceDatasetResponse
 ): DatasetAsset {
   return buildTrackerDatasetAsset(
     TRACKER_FOLDER_TYPE.SOURCE_DATASETS,


### PR DESCRIPTION
## Summary

Closes #3197. Part of #3193.

**Journal** and **Reference Author** were filterable on the removed Source Studies tab and had not been carried across. The tracker's source-dataset endpoint returns neither field — verified against the live tracker, a source-dataset record carries `publicationString`, `sourceStudyId` and `sourceStudyTitle`, while `journal` and `referenceAuthor` exist only on the source-study record. So this joins the source study onto each source dataset at build time and adds both as filter-only columns.

## Changes

**The join** — `utils/trackerAtlasPages.ts`. `getTrackerContentStaticProps` already fetched both collections in one `Promise.all` and already enriched each dataset with `datasetAsset`; that step now also joins by `sourceStudyId`. `hcaProjectId` rides along for #3199 so the join lives in one place. `?? null` throughout, since `getStaticProps` cannot serialize `undefined`.

**The filters** — `Datasets/.../tracker/components/table/`:
- `accessor.ts` — `buildJournal` / `buildReferenceAuthor`, matching the existing `buildIntegratedObjects` pattern.
- `columns.ts` — `JOURNAL` and `REFERENCE_AUTHOR`, both `enableColumnFilter` with `filterFn: "arrIncludesSome"`.
- `utils.ts` — both hidden via `getColumnVisibility`, alongside `integratedObject`.
- `meta.ts` — both registered in `META.categoryGroups[0].categoryConfigs` for the sidebar.

**Types** — `@types/network.ts` adds `journal`, `referenceAuthor` and `hcaProjectId` to `TrackerSourceDataset`.

## Also in this PR

Two adjacent changes, each its own commit:

- **`cc36ca41` — drops the readerless `trackerSourceStudies` static prop and `AtlasContext` field.** #3194 deliberately kept these and designated #3197 as what replaces them; the per-dataset join now does. Nothing read them. **Saves 36,530 bytes of `__NEXT_DATA__` per tracker atlas page** (`datasets.html` 152,535 → 116,005). The fetch itself stays — the join needs it.
- **`bcac644f` — collapses the column filters into the drawer below 1024px, up from 820px.** The chip row measures ~820px in the browser, which was *also* the old breakpoint, so the chips overflowed the viewport at any width just above it once these two filters were added. The value is now `FILTER_DRAWER_BREAKPOINT` in `components/common/Filters/constants.ts`, shared by `ColumnFilters` and `ColumnFilterTags` so the chips and their selected-value tags always switch together.

## Verification

Against live tracker data for Breast v1.0, read back out of the built `__NEXT_DATA__`:

- 7 source datasets ↔ 7 source studies, **zero unmatched `sourceStudyId`**.
- Journals: Nature, Developmental Cell, Cell Systems, Nature Genetics (×2), Nature Communications, The EMBO Journal. Authors: Kumar, Gray, Murrow, Nee, Reed, Twigger, Pal. Both match the issue exactly.
- `hcaProjectId` present on all 7, `null` for Reed — the case #3199's empty-cell criterion covers.
- Chip row width measured in-browser at 815–820px (Assay 85, Tissue 88, Disease 97, Source Study 134, Integrated Object 160, Journal 94, Reference Author 162).
- `npm run lint` (0 errors), `npm run check-format`, `npx tsc --noEmit`, `npm run build-prod:data-portal` (64/64 pages) all pass.

## Notes for review

- **A join miss cannot hide a dataset.** An unmatched `sourceStudyId` leaves all three fields `null` rather than dropping the row: journal facets as `"Unpublished"`, author as `LABEL.UNSPECIFIED`. The labels differ deliberately — `journal` is legitimately null for an unpublished study, whereas the tracker always sets `referenceAuthor`, so a null there means only a join miss.
- `||` rather than `??` in both accessors, so an empty-string journal from Crossref cannot render a blank, unlabelled filter option.
- `hcaProjectId` has no consumer until #3199, as the issue specifies.
- **Pre-existing wart worth its own ticket, not addressed here:** `TrackerSourceStudy` models `journal` and `doi` as independently nullable, so a study that *is* published but whose Crossref record lacks a journal will facet as "Unpublished" while its Source Study cell renders a live DOI link. This PR preserves the old tab's behaviour, which the acceptance criteria require.
- The "fits at 1024" conclusion is arithmetic (820 needed vs ~980 available after gutters) — the 820px content width was measured directly; Fran verified filters fit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)