### PR TITLE
refactor: derive the tracker -r<revision> file name from one shared helper (#3200)

### DIFF
--- a/@types/network.ts
+++ b/@types/network.ts
@@ -113,9 +113,13 @@ export type IntegratedAtlasRow = AtlasRow &
 
 export interface DatasetAsset {
   downloadURL: string;
-  fileName?: string; // Versioned file name with extension, e.g. "ihbca-v1-gray-2022-r1.h5ad". Set for tracker-built assets only; CXG assets are rendered by CXGDownloadCell, which does not use it.
   fileSize: number;
   fileType: CXG_DATASET_FILE_TYPE;
+  // Published file name with extension, e.g. "ihbca-v1-gray-2022-r1.h5ad",
+  // derived by `buildVersionedFileName`. NOT the tracker's own `fileName`,
+  // which is an internal working name. Set for tracker-built assets only; CXG
+  // assets are rendered by CXGDownloadCell, which does not use it.
+  versionedFileName?: string;
 }
 
 export interface IntegratedAtlas {
@@ -201,6 +205,10 @@ export interface TrackerComponentAtlas {
   cellCount: number;
   disease: string[];
   fileId: string;
+  // The tracker's internal working file name, e.g.
+  // "gray2022-r1-wip-2-edit-2026-08-25-03-50-06.h5ad". This is NOT the
+  // published object name - use `datasetAsset.versionedFileName` for anything
+  // user-facing or for building a download URL.
   fileName: string;
   geneCount: number;
   id: string;
@@ -227,6 +235,10 @@ export interface TrackerSourceDataset {
   disease: string[];
   doi: string | null;
   fileId: string;
+  // The tracker's internal working file name, e.g.
+  // "gray2022-r1-wip-2-edit-2026-08-25-03-50-06.h5ad". This is NOT the
+  // published object name - use `datasetAsset.versionedFileName` for anything
+  // user-facing or for building a download URL.
   fileName: string;
   geneCount: number;
   hcaProjectId: string | null; // Joined from the source study; null when the study has no HCA project or the join misses.

--- a/@types/network.ts
+++ b/@types/network.ts
@@ -113,6 +113,7 @@ export type IntegratedAtlasRow = AtlasRow &
 
 export interface DatasetAsset {
   downloadURL: string;
+  fileName?: string; // Versioned file name with extension, e.g. "ihbca-v1-gray-2022-r1.h5ad". Set for tracker-built assets only; CXG assets are rendered by CXGDownloadCell, which does not use it.
   fileSize: number;
   fileType: CXG_DATASET_FILE_TYPE;
 }

--- a/components/HCABioNetworks/Network/Atlas/components/SourceDatasets/components/MainColumn/components/table/viewBuilder.ts
+++ b/components/HCABioNetworks/Network/Atlas/components/SourceDatasets/components/MainColumn/components/table/viewBuilder.ts
@@ -8,7 +8,7 @@ import * as C from "../../../../../../../../..";
 import type { TrackerSourceDataset } from "../../../../../../../../../../@types/network";
 import {
   buildTrackerAnalysisPortals,
-  splitFileName,
+  buildTrackerDownloadCellProps,
 } from "../../../../../../../../../../utils/trackerNetwork";
 
 const DOI_BASE_URL = "https://doi.org/";
@@ -33,15 +33,9 @@ export function renderCellCount(
 export function renderDownload(
   ctx: CellContext<TrackerSourceDataset, unknown>
 ): JSX.Element | null {
-  const { datasetAsset } = ctx.row.original;
-  if (!datasetAsset?.fileName) return null;
-  const { ext: format, stem } = splitFileName(datasetAsset.fileName);
-  return C.TrackerDownloadCell({
-    downloadUrl: datasetAsset.downloadURL,
-    fileName: stem,
-    fileSize: datasetAsset.fileSize,
-    format,
-  });
+  const props = buildTrackerDownloadCellProps(ctx.row.original.datasetAsset);
+  if (!props) return null;
+  return C.TrackerDownloadCell(props);
 }
 
 /**

--- a/components/HCABioNetworks/Network/Atlas/components/SourceDatasets/components/MainColumn/components/table/viewBuilder.ts
+++ b/components/HCABioNetworks/Network/Atlas/components/SourceDatasets/components/MainColumn/components/table/viewBuilder.ts
@@ -33,12 +33,12 @@ export function renderCellCount(
 export function renderDownload(
   ctx: CellContext<TrackerSourceDataset, unknown>
 ): JSX.Element | null {
-  const { baseFileName, datasetAsset, revision } = ctx.row.original;
-  if (!datasetAsset) return null;
-  const { ext: format, stem } = splitFileName(baseFileName);
+  const { datasetAsset } = ctx.row.original;
+  if (!datasetAsset?.fileName) return null;
+  const { ext: format, stem } = splitFileName(datasetAsset.fileName);
   return C.TrackerDownloadCell({
     downloadUrl: datasetAsset.downloadURL,
-    fileName: `${stem}-r${revision}`,
+    fileName: stem,
     fileSize: datasetAsset.fileSize,
     format,
   });

--- a/utils/trackerNetwork.ts
+++ b/utils/trackerNetwork.ts
@@ -72,16 +72,13 @@ export function buildTrackerSourceDatasetAsset(
 /**
  * Builds the S3 download URL for a tracker file.
  * @param folderType - Folder type.
- * @param baseFileName - Base file name.
- * @param revision - File revision number.
+ * @param fileName - Versioned file name, from `buildVersionedFileName`.
  * @returns full S3 download URL.
  */
 function buildTrackerDownloadUrl(
   folderType: TrackerFolderType,
-  baseFileName: string,
-  revision: number
+  fileName: string
 ): string {
-  const fileName = buildVersionedFileName(baseFileName, revision);
   return `${S3_BASE_URL}/${folderType}/${fileName}`;
 }
 
@@ -127,8 +124,10 @@ function buildTrackerDatasetAsset(
   revision: number,
   sizeBytes: number
 ): DatasetAsset {
+  const fileName = buildVersionedFileName(baseFileName, revision);
   return {
-    downloadURL: buildTrackerDownloadUrl(folderType, baseFileName, revision),
+    downloadURL: buildTrackerDownloadUrl(folderType, fileName),
+    fileName,
     fileSize: sizeBytes,
     fileType: CXG_DATASET_FILE_TYPE.H5AD,
   };
@@ -160,7 +159,7 @@ export function splitFileName(fileName: string): {
  * @param revision - File revision number.
  * @returns versioned file name.
  */
-function buildVersionedFileName(
+export function buildVersionedFileName(
   baseFileName: string,
   revision: number
 ): string {

--- a/utils/trackerNetwork.ts
+++ b/utils/trackerNetwork.ts
@@ -79,7 +79,7 @@ function buildTrackerDownloadUrl(
   folderType: TrackerFolderType,
   fileName: string
 ): string {
-  return `${S3_BASE_URL}/${folderType}/${fileName}`;
+  return `${S3_BASE_URL}/${folderType}/${encodeURIComponent(fileName)}`;
 }
 
 /**
@@ -124,12 +124,36 @@ function buildTrackerDatasetAsset(
   revision: number,
   sizeBytes: number
 ): DatasetAsset {
-  const fileName = buildVersionedFileName(baseFileName, revision);
+  const versionedFileName = buildVersionedFileName(baseFileName, revision);
   return {
-    downloadURL: buildTrackerDownloadUrl(folderType, fileName),
-    fileName,
+    downloadURL: buildTrackerDownloadUrl(folderType, versionedFileName),
     fileSize: sizeBytes,
     fileType: CXG_DATASET_FILE_TYPE.H5AD,
+    versionedFileName,
+  };
+}
+
+/**
+ * Builds the props a `TrackerDownloadCell` needs from a tracker-built asset,
+ * so the stem/extension display convention lives in one place.
+ * @param asset - Dataset asset carrying a `versionedFileName`.
+ * @returns cell props, or null when the asset has no published file name.
+ */
+export function buildTrackerDownloadCellProps(
+  asset: DatasetAsset | undefined
+): {
+  downloadUrl: string;
+  fileName: string;
+  fileSize: number;
+  format: string;
+} | null {
+  if (!asset?.versionedFileName) return null;
+  const { ext, stem } = splitFileName(asset.versionedFileName);
+  return {
+    downloadUrl: asset.downloadURL,
+    fileName: stem,
+    fileSize: asset.fileSize,
+    format: ext,
   };
 }
 

--- a/viewModelBuilders/viewModelBuilders.ts
+++ b/viewModelBuilders/viewModelBuilders.ts
@@ -25,7 +25,7 @@ import * as C from "../components";
 import { MetadataValueTuple } from "../components/common/NTagCell/components/PinnedNTagCell/pinnedNTagCell";
 import { NETWORKS_ROUTE } from "../constants/routes";
 import { formatCountSize } from "../utils/formatCountSize";
-import { splitFileName } from "../utils/trackerNetwork";
+import { buildTrackerDownloadCellProps } from "../utils/trackerNetwork";
 import { DISEASE } from "./entities";
 
 /**
@@ -99,15 +99,11 @@ function getAtlasesActionsColumnDef(
     accessorKey: "actions",
     cell: isTracker
       ? ({ row }): JSX.Element | null => {
-          const asset = row.original.datasetAssets[0];
-          if (!asset?.fileName) return null;
-          const { ext: format, stem: fileName } = splitFileName(asset.fileName);
-          return C.TrackerDownloadCell({
-            downloadUrl: asset.downloadURL,
-            fileName,
-            fileSize: asset.fileSize,
-            format,
-          });
+          const props = buildTrackerDownloadCellProps(
+            row.original.datasetAssets[0]
+          );
+          if (!props) return null;
+          return C.TrackerDownloadCell(props);
         }
       : ({ row }): JSX.Element =>
           C.CXGDownloadCell({

--- a/viewModelBuilders/viewModelBuilders.ts
+++ b/viewModelBuilders/viewModelBuilders.ts
@@ -100,10 +100,8 @@ function getAtlasesActionsColumnDef(
     cell: isTracker
       ? ({ row }): JSX.Element | null => {
           const asset = row.original.datasetAssets[0];
-          if (!asset) return null;
-          const { ext: format, stem: fileName } = splitFileName(
-            asset.downloadURL.split("/").pop() || ""
-          );
+          if (!asset?.fileName) return null;
+          const { ext: format, stem: fileName } = splitFileName(asset.fileName);
           return C.TrackerDownloadCell({
             downloadUrl: asset.downloadURL,
             fileName,


### PR DESCRIPTION
## Summary

Closes #3200. Part of #3193.

The `<stem>-r<revision><ext>` convention was derived three different ways, in two different styles. This carries the published name on the dataset asset — built once, alongside the download URL it already derives — so the convention lives in exactly one place. `#3195` was about to add a fourth derivation.

**Before:**

| Site | How it derived the name |
| --- | --- |
| `utils/trackerNetwork.ts` | `buildVersionedFileName` — canonical, but private |
| source datasets download cell | re-implemented the suffix inline as `` `${stem}-r${revision}` `` |
| integrated objects download cell | popped the last segment off `asset.downloadURL` and split *that* |

**After:** `buildVersionedFileName` is the only place `-r${revision}` appears, and nothing derives a file name from a URL.

## Changes

- `@types/network.ts` — `DatasetAsset.versionedFileName?`, the published name with extension. Optional, since CXG assets are built elsewhere and rendered by `CXGDownloadCell`, which does not use it.
- `utils/trackerNetwork.ts` — exports `buildVersionedFileName`; `buildTrackerDatasetAsset` derives the name once and passes it to `buildTrackerDownloadUrl` (whose signature and JSDoc changed to match).
- Both download cells read the name off the asset via a new shared `buildTrackerDownloadCellProps`.

## ⚠️ Deviation from the issue: the field is `versionedFileName`, not `fileName`

#3200 specifies adding **`fileName`** to `DatasetAsset`. I named it **`versionedFileName`** instead, because `fileName` would have collided with an existing field of the same name meaning something else.

`TrackerSourceDataset.fileName` and `TrackerComponentAtlas.fileName` already exist as required strings holding the tracker's **internal working name**. Checked against all seven live Breast v1.0 records — they differ from the published name on *every one*:

```
tracker API fileName            gray2022-r1-wip-2-edit-2026-08-25-03-50-06.h5ad
baseFileName + revision         ihbca-v1-gray-2022-r1.h5ad     <- what S3 actually serves
```

Had the asset field also been called `fileName`, then `sd.fileName !== sd.datasetAsset.fileName` on every record, with the wrong one being the shorter, more obvious reach. #3195's File Name column is exactly where that mistake would be made, and it would be silent — the working name is a required `string` that renders as a plausible `.h5ad`.

So alongside the rename, both tracker `fileName` fields now carry a comment saying they are the working name and pointing at `versionedFileName`. I've commented on #3195 with the same warning.

The issue's *intent* — the asset carries the versioned name, derived in one place — is met. Say the word if you'd rather it match the issue's literal wording.

## Also addressed from review

- **Shared cell props.** The two download cells had become structurally identical (guard, `splitFileName`, same four props). `buildTrackerDownloadCellProps` puts the stem/extension display convention in one place too, so a change to the naming convention can't drift between them. Both call sites are now three lines.
- **URL encoding.** `buildTrackerDownloadUrl` now wraps the name in `encodeURIComponent`. Pre-existing gap — a name containing a space, `#`, or `?` produced a broken link. Every generated URL is unchanged today, since all current names are slugs.

## Deliberately not done

- **No tracker-specific `DatasetAsset` subtype.** Suggested so the render paths could require `versionedFileName` at compile time rather than degrading to a hidden download button. `buildTrackerDatasetAsset` is the only tracker asset builder and always sets it, and #3200 specifies the field as optional. Reasonable follow-up, not this PR.
- **No alphabetical reorder of `utils/trackerNetwork.ts`.** It is already non-alphabetical at HEAD (`mapTrackerComponentAtlasToIntegratedAtlas` precedes `buildTrackerDatasetAsset`), so moving one function wouldn't make it compliant — it needs its own pass.
- **`buildVersionedFileName` is exported but has no external caller yet.** That is deliberate and specified: #3189 cites this function and `splitFileName` as untestable today, and #3200's notes say to seed unit tests for exactly those two once #3190 lands.

## Verification

- **All 175 `.h5ad` download URLs byte-for-byte identical** to a baseline captured from the build before any change — including after adding `encodeURIComponent`.
- **Displayed names identical** on `source-datasets.html` and `breast-v1.html` (8 each).
- Gray et al. resolves to `versionedFileName: "ihbca-v1-gray-2022-r1.h5ad"`, rendered as stem `ihbca-v1-gray-2022-r1` plus format `.h5ad` — the AC's exact case. All 7 assets carry it.
- `` `-r${revision}` `` appears once, at `utils/trackerNetwork.ts:191`. `grep` for `downloadURL.split` returns nothing.
- `npm run lint` (0 errors), `npm run check-format`, `npx tsc --noEmit`, `npm run build-prod:data-portal` (64/64) all pass — re-run after rebasing onto `main` post-#3204.

## Tests

Skipped: #3190 has not landed, so there is still no test tooling in the repo (no `test` script, no Jest/Vitest in `devDependencies`, no config). #3200's note to seed `buildVersionedFileName` / `splitFileName` tests carries over to whoever lands #3190 — the export is already in place for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)