### PR TITLE
feat: atlas source datasets table: stack file name over source study in one pinned column (#3195)

### DIFF
--- a/components/HCABioNetworks/Network/Atlas/components/SourceDatasets/components/MainColumn/components/table/accessor.ts
+++ b/components/HCABioNetworks/Network/Atlas/components/SourceDatasets/components/MainColumn/components/table/accessor.ts
@@ -36,3 +36,14 @@ export function buildJournal(row: TrackerSourceDataset): string {
 export function buildReferenceAuthor(row: TrackerSourceDataset): string {
   return row.referenceAuthor || LABEL.UNSPECIFIED;
 }
+
+/**
+ * Returns the file name shown in the pinned column, so the column sorts on the
+ * value it displays rather than on the unrevisioned base name. Mirrors the
+ * fallback in `FileNameCell` so no row ever sorts on an empty value.
+ * @param row - Tracker source dataset.
+ * @returns versioned file name, falling back to the base file name.
+ */
+export function buildVersionedFileNameValue(row: TrackerSourceDataset): string {
+  return row.datasetAsset?.versionedFileName || row.baseFileName;
+}

--- a/components/HCABioNetworks/Network/Atlas/components/SourceDatasets/components/MainColumn/components/table/columns.ts
+++ b/components/HCABioNetworks/Network/Atlas/components/SourceDatasets/components/MainColumn/components/table/columns.ts
@@ -14,12 +14,13 @@ import {
   buildIntegratedObjects,
   buildJournal,
   buildReferenceAuthor,
+  buildVersionedFileNameValue,
 } from "./accessor";
 import {
   renderCellCount,
   renderDownload,
   renderExplore,
-  renderSourceStudy,
+  renderFileName,
 } from "./viewBuilder";
 
 const ASSAY = {
@@ -76,6 +77,16 @@ const EXPLORE = {
   meta: { width: "auto" },
 } as ColumnDef<TrackerSourceDataset>;
 
+const FILE_NAME = {
+  accessorFn: buildVersionedFileNameValue,
+  cell: renderFileName,
+  enableColumnFilter: false,
+  header: "File Name",
+  id: "fileName",
+  meta: { columnPinned: true, width: { max: "2.4fr", min: "260px" } },
+  sortingFn,
+} as ColumnDef<TrackerSourceDataset>;
+
 const INTEGRATED_OBJECTS = {
   accessorFn: buildIntegratedObjects,
   enableColumnFilter: true,
@@ -102,13 +113,10 @@ const REFERENCE_AUTHOR = {
 
 const SOURCE_STUDY = {
   accessorKey: "publicationString",
-  cell: renderSourceStudy,
   enableColumnFilter: true,
   filterFn: "arrIncludesSome",
   header: "Source Study",
   id: "sourceStudy",
-  meta: { width: { max: "1.2fr", min: "200px" } },
-  sortingFn,
 } as ColumnDef<TrackerSourceDataset>;
 
 const TISSUE = {
@@ -122,18 +130,8 @@ const TISSUE = {
   sortingFn,
 } as ColumnDef<TrackerSourceDataset>;
 
-const TITLE = {
-  accessorKey: "title",
-  enableColumnFilter: false,
-  header: "Dataset",
-  id: "title",
-  meta: { columnPinned: true, width: { max: "2fr", min: "200px" } },
-  sortingFn,
-} as ColumnDef<TrackerSourceDataset>;
-
 export const COLUMNS: ColumnDef<TrackerSourceDataset>[] = [
-  TITLE,
-  SOURCE_STUDY,
+  FILE_NAME,
   ASSAY,
   TISSUE,
   DISEASE,
@@ -143,4 +141,5 @@ export const COLUMNS: ColumnDef<TrackerSourceDataset>[] = [
   INTEGRATED_OBJECTS,
   JOURNAL,
   REFERENCE_AUTHOR,
+  SOURCE_STUDY,
 ];

--- a/components/HCABioNetworks/Network/Atlas/components/SourceDatasets/components/MainColumn/components/table/components/FileNameCell/constants.ts
+++ b/components/HCABioNetworks/Network/Atlas/components/SourceDatasets/components/MainColumn/components/table/components/FileNameCell/constants.ts
@@ -1,0 +1,1 @@
+export const DOI_BASE_URL = "https://doi.org/";

--- a/components/HCABioNetworks/Network/Atlas/components/SourceDatasets/components/MainColumn/components/table/components/FileNameCell/fileNameCell.tsx
+++ b/components/HCABioNetworks/Network/Atlas/components/SourceDatasets/components/MainColumn/components/table/components/FileNameCell/fileNameCell.tsx
@@ -1,0 +1,48 @@
+import {
+  ANCHOR_TARGET,
+  REL_ATTRIBUTE,
+} from "@databiosphere/findable-ui/lib/components/Links/common/entities";
+import { Link } from "@databiosphere/findable-ui/lib/components/Links/components/Link/link";
+import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
+import { Stack, Typography } from "@mui/material";
+import type { JSX } from "react";
+import { DOI_BASE_URL } from "./constants";
+import type { Props } from "./types";
+
+/**
+ * Pinned cell stacking the published file name over the source study citation.
+ * The primary line is the versioned name carried on the dataset asset, so it
+ * always matches the file the row's Download button delivers.
+ * @param props - Component props.
+ * @param props.row - Tracker source dataset.
+ * @returns stacked file name and source study cell.
+ */
+export const FileNameCell = ({ row }: Props): JSX.Element => {
+  const { baseFileName, datasetAsset, doi, publicationString } = row;
+  // `versionedFileName` is set for every tracker source dataset, but it is
+  // optional on the shared asset type - fall back to the unversioned base name
+  // so the pinned column, which identifies the row in the collapsed layout,
+  // can never render empty.
+  const fileName = datasetAsset?.versionedFileName || baseFileName;
+  return (
+    <Stack spacing={2} useFlexGap>
+      <Typography variant={TYPOGRAPHY_PROPS.VARIANT.BODY_400}>
+        {fileName}
+      </Typography>
+      {publicationString && (
+        <Typography
+          color={TYPOGRAPHY_PROPS.COLOR.INK_LIGHT}
+          component="div"
+          variant={TYPOGRAPHY_PROPS.VARIANT.BODY_SMALL_400}
+        >
+          <Link
+            label={publicationString}
+            rel={REL_ATTRIBUTE.NO_OPENER_NO_REFERRER}
+            target={ANCHOR_TARGET.BLANK}
+            url={doi ? `${DOI_BASE_URL}${doi}` : ""}
+          />
+        </Typography>
+      )}
+    </Stack>
+  );
+};

--- a/components/HCABioNetworks/Network/Atlas/components/SourceDatasets/components/MainColumn/components/table/components/FileNameCell/types.ts
+++ b/components/HCABioNetworks/Network/Atlas/components/SourceDatasets/components/MainColumn/components/table/components/FileNameCell/types.ts
@@ -1,0 +1,5 @@
+import type { TrackerSourceDataset } from "../../../../../../../../../../../../@types/network";
+
+export interface Props {
+  row: TrackerSourceDataset;
+}

--- a/components/HCABioNetworks/Network/Atlas/components/SourceDatasets/components/MainColumn/components/table/hook.ts
+++ b/components/HCABioNetworks/Network/Atlas/components/SourceDatasets/components/MainColumn/components/table/hook.ts
@@ -28,7 +28,7 @@ export const useTable = (
     enableRowPreview: false,
     getRowId: (row) => row.id,
     initialState: {
-      sorting: [{ desc: SORT_DIRECTION.ASCENDING, id: "title" }],
+      sorting: [{ desc: SORT_DIRECTION.ASCENDING, id: "fileName" }],
     },
     meta: META,
     state: {

--- a/components/HCABioNetworks/Network/Atlas/components/SourceDatasets/components/MainColumn/components/table/utils.ts
+++ b/components/HCABioNetworks/Network/Atlas/components/SourceDatasets/components/MainColumn/components/table/utils.ts
@@ -3,9 +3,9 @@ import type { TrackerSourceDataset } from "../../../../../../../../../../@types/
 
 /**
  * Returns the column visibility state for the tracker source datasets table.
- * The "Integrated Object", "Journal" and "Reference Author" columns are
- * filter-only, and the "Explore" column is displayed only when at least one
- * dataset has a CAP link.
+ * The "Integrated Object", "Journal", "Reference Author" and "Source Study"
+ * columns are filter-only, and the "Explore" column is displayed only when at
+ * least one dataset has a CAP link.
  * @param data - Tracker source datasets.
  * @returns column visibility state.
  */
@@ -17,5 +17,6 @@ export function getColumnVisibility(
     integratedObject: false,
     journal: false,
     referenceAuthor: false,
+    sourceStudy: false,
   };
 }

--- a/components/HCABioNetworks/Network/Atlas/components/SourceDatasets/components/MainColumn/components/table/viewBuilder.ts
+++ b/components/HCABioNetworks/Network/Atlas/components/SourceDatasets/components/MainColumn/components/table/viewBuilder.ts
@@ -1,7 +1,3 @@
-import {
-  ANCHOR_TARGET,
-  REL_ATTRIBUTE,
-} from "@databiosphere/findable-ui/lib/components/Links/common/entities";
 import type { CellContext } from "@tanstack/react-table";
 import type { JSX } from "react";
 import * as C from "../../../../../../../../..";
@@ -10,8 +6,7 @@ import {
   buildTrackerAnalysisPortals,
   buildTrackerDownloadCellProps,
 } from "../../../../../../../../../../utils/trackerNetwork";
-
-const DOI_BASE_URL = "https://doi.org/";
+import { FileNameCell } from "./components/FileNameCell/fileNameCell";
 
 /**
  * Renders the cell count as a locale-formatted string.
@@ -52,20 +47,13 @@ export function renderExplore(
 }
 
 /**
- * Renders the source study shorthand citation as a link to the DOI.
- * @param ctx - Cell context with publicationString from accessorKey.
- * @returns Link component, or null if no citation.
+ * Renders the pinned cell stacking the published file name over the source
+ * study citation.
+ * @param ctx - Cell context.
+ * @returns FileNameCell component.
  */
-export function renderSourceStudy(
-  ctx: CellContext<TrackerSourceDataset, string | null>
-): JSX.Element | null {
-  const label = ctx.getValue();
-  if (!label) return null;
-  const { doi } = ctx.row.original;
-  return C.Link({
-    label,
-    rel: REL_ATTRIBUTE.NO_OPENER_NO_REFERRER,
-    target: ANCHOR_TARGET.BLANK,
-    url: doi ? `${DOI_BASE_URL}${doi}` : "",
-  });
+export function renderFileName(
+  ctx: CellContext<TrackerSourceDataset, unknown>
+): JSX.Element {
+  return FileNameCell({ row: ctx.row.original });
 }

--- a/components/HCABioNetworks/Network/Atlas/components/SourceDatasets/components/MainColumn/components/table/viewBuilder.tsx
+++ b/components/HCABioNetworks/Network/Atlas/components/SourceDatasets/components/MainColumn/components/table/viewBuilder.tsx
@@ -1,11 +1,12 @@
 import type { CellContext } from "@tanstack/react-table";
 import type { JSX } from "react";
-import * as C from "../../../../../../../../..";
 import type { TrackerSourceDataset } from "../../../../../../../../../../@types/network";
 import {
   buildTrackerAnalysisPortals,
   buildTrackerDownloadCellProps,
 } from "../../../../../../../../../../utils/trackerNetwork";
+import { TrackerDownloadCell } from "../../../../../../../../../common/Table/components/Cell/components/TrackerDownloadCell/trackerDownloadCell";
+import { AnalysisPortalCell } from "../../../../../Overview/components/MainColumn/components/AnalysisPortalCell/analysisPortalCell";
 import { FileNameCell } from "./components/FileNameCell/fileNameCell";
 
 /**
@@ -30,7 +31,7 @@ export function renderDownload(
 ): JSX.Element | null {
   const props = buildTrackerDownloadCellProps(ctx.row.original.datasetAsset);
   if (!props) return null;
-  return C.TrackerDownloadCell(props);
+  return <TrackerDownloadCell {...props} />;
 }
 
 /**
@@ -43,7 +44,7 @@ export function renderExplore(
 ): JSX.Element | null {
   const analysisPortals = buildTrackerAnalysisPortals(ctx.row.original.capUrl);
   if (analysisPortals.length === 0) return null;
-  return C.AnalysisPortalCell({ analysisPortals });
+  return <AnalysisPortalCell analysisPortals={analysisPortals} />;
 }
 
 /**
@@ -55,5 +56,5 @@ export function renderExplore(
 export function renderFileName(
   ctx: CellContext<TrackerSourceDataset, unknown>
 ): JSX.Element {
-  return FileNameCell({ row: ctx.row.original });
+  return <FileNameCell row={ctx.row.original} />;
 }

--- a/utils/trackerNetwork.ts
+++ b/utils/trackerNetwork.ts
@@ -9,6 +9,7 @@ import type {
 import { CXG_DATASET_FILE_TYPE } from "../@types/network";
 import { processNullElements } from "../apis/azul/hca-dcp/common/utils";
 import type { PublishedAtlas } from "../apis/tracker/types";
+import type { TrackerDownloadCellProps } from "../components/common/Table/components/Cell/components/TrackerDownloadCell/types";
 import { buildCAPAnalysisPortal, buildCXGDataPortalLink } from "./network";
 
 const S3_BASE_URL = "https://humancellatlas.s3.amazonaws.com/temp/atlases";
@@ -141,12 +142,7 @@ function buildTrackerDatasetAsset(
  */
 export function buildTrackerDownloadCellProps(
   asset: DatasetAsset | undefined
-): {
-  downloadUrl: string;
-  fileName: string;
-  fileSize: number;
-  format: string;
-} | null {
+): TrackerDownloadCellProps | null {
   if (!asset?.versionedFileName) return null;
   const { ext, stem } = splitFileName(asset.versionedFileName);
   return {


### PR DESCRIPTION
## Summary

Closes #3195. Part of #3193.

The table opened with two columns saying one thing badly — **Dataset** (`title`, e.g. "Gray et al. 2022, Developmental Cell") and **Source Study** (`publicationString`, e.g. "Gray (2022) Developmental Cell") — which restated each other, burned two columns, and identified nothing about the file the Download button delivers. Both are replaced by one pinned column stacking the published file name over the DOI-linked citation.

## Changes

Under `SourceDatasets/components/MainColumn/components/table/`:

- **New `components/FileNameCell/`** — `fileNameCell.tsx`, `types.ts`, `constants.ts`. A MUI `Stack` with the file name at `body-400` over the citation at `ink.light` / `body-small-400`, matching the BRC Analytics stacked-cell treatment.
- `accessor.ts` — `buildVersionedFileNameValue`, so the column sorts on the value it displays rather than the unrevisioned base name.
- `columns.ts` — `TITLE` becomes `FILE_NAME` (`id: "fileName"`, header **File Name**, pinned, first). `SOURCE_STUDY` keeps its `accessorKey` and filter config but loses its `cell`.
- `utils.ts` — `sourceStudy: false` joins the filter-only columns.
- `hook.ts` — initial sort moves from the removed `"title"` to `"fileName"`.

The name comes from `datasetAsset.versionedFileName` (#3200), so the `-r<revision>` suffix is not derived here.

## ⚠️ Deviation: `renderSourceStudy` was removed, not reused

#3195 says to "reuse the existing `renderSourceStudy` link logic from `viewBuilder.ts`". I moved that logic into the new cell and **deleted the function**, rather than keeping it.

Making `SOURCE_STUDY` filter-only means its `cell` is never reached — hidden columns are not rendered — so `renderSourceStudy` would have been dead code. The repo's other filter-only columns (`INTEGRATED_OBJECTS`, `JOURNAL`, `REFERENCE_AUTHOR`) carry no `cell` at all, so I matched that shape and also dropped the now-meaningless `meta.width`. `DOI_BASE_URL` moved from `viewBuilder.ts` into the new cell's `constants.ts`, its only remaining consumer.

I read "reuse the logic" as reuse-the-behaviour rather than keep-the-function; flag it if you would rather the function stayed.

## Verification

Against the built page for Breast v1.0:

- Headers are now `File Name, Assay, Tissue, Disease, Cell Count, Explore, Download` — both `Dataset` and the `Source Study` column are gone.
- **The Source Study filter survives** — all seven chips still render in the sidebar, faceting over `publicationString`.
- All seven versioned names render **as text in the document body**, not merely in `__NEXT_DATA__`, each with a `doi.org` link carrying `rel="noopener noreferrer"`.
- **No tracker working name is shown**: zero occurrences of `-wip-` or `edit-2026` in the rendered body. The seven hits inside `__NEXT_DATA__` are the tracker's own `fileName` field, which the page carries but never displays.
- Loads sorted ascending by file name (gray → twigger), checked against `sorted()`.
- No `title` column id or `row.title` reference remains in the table directory.
- Column width verified in the browser at desktop width.
- `npm run lint` (0 errors), `npm run check-format`, `npx tsc --noEmit`, `npm run build-prod:data-portal` (64/64) all pass.

## From review

- **The pinned cell can no longer render empty.** `datasetAsset` is optional on the type and `publicationString` is nullable, so a row with neither would have produced a bare `Stack` — and because this is the pinned column it identifies the row in the collapsed layout. The primary line now falls back to `baseFileName` (a required field), and `buildVersionedFileNameValue` mirrors that fallback so such rows cannot sort on an empty string either. **Not** falling back to `title`, which #3195 puts out of scope for the pinned slot.
- **`buildTrackerDownloadCellProps` now returns the exported `TrackerDownloadCellProps`** instead of an inline duplicate of that shape — this also answers a note on #3206.
- `FILE_NAME` moved to its alphabetical position among the column consts; `JSX` is a `type` import.
- **Cells now render as real elements.** `viewBuilder.ts` is renamed `viewBuilder.tsx` and all three renderers return JSX (`<TrackerDownloadCell {...props} />`, `<AnalysisPortalCell … />`, `<FileNameCell … />`) instead of invoking components as plain functions, so each cell gets its own component boundary. This mattered beyond the new cell: `renderDownload` was calling `TrackerDownloadCell`, which uses `useDialog()`, so that hook was attaching to whichever component rendered the cell. The `import * as C` barrel namespace is replaced by direct imports. The same pattern remains at 17 call sites in `viewModelBuilders.ts` (including a second `useDialog` component) — out of scope here, filed as #3211.

## Not addressed

- **Five tracker source-dataset fields now ship in props with no reader** — `fileName`, `fileId`, `sourceStudyTitle`, `geneCount`, and `title`, which this PR orphans by removing its only consumer. Added to #3205 rather than fixed here, since trimming them needs a projection step between the API response and the props.

## Out of scope

The external-link affordance on the citation line — #3196, which builds on this cell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1354" height="1052" alt="image" src="https://github.com/user-attachments/assets/752c38e1-7d0e-48c8-b918-4f94a61649bf" />

