### PR TITLE
feat: atlas source datasets table: add an external-link icon to the source study citation (#3196)

### DIFF
--- a/components/HCABioNetworks/Network/Atlas/components/SourceDatasets/components/MainColumn/components/table/accessor.ts
+++ b/components/HCABioNetworks/Network/Atlas/components/SourceDatasets/components/MainColumn/components/table/accessor.ts
@@ -39,8 +39,10 @@ export function buildReferenceAuthor(row: TrackerSourceDataset): string {
 
 /**
  * Returns the file name shown in the pinned column, so the column sorts on the
- * value it displays rather than on the unrevisioned base name. Mirrors the
- * fallback in `FileNameCell` so no row ever sorts on an empty value.
+ * value it displays rather than on the unrevisioned base name. `FileNameCell`
+ * renders this same value, so the two cannot drift. `versionedFileName` is set
+ * for every tracker source dataset but is optional on the shared asset type,
+ * hence the fallback to the required base name.
  * @param row - Tracker source dataset.
  * @returns versioned file name, falling back to the base file name.
  */

--- a/components/HCABioNetworks/Network/Atlas/components/SourceDatasets/components/MainColumn/components/table/components/FileNameCell/constants.ts
+++ b/components/HCABioNetworks/Network/Atlas/components/SourceDatasets/components/MainColumn/components/table/components/FileNameCell/constants.ts
@@ -1,1 +1,6 @@
 export const DOI_BASE_URL = "https://doi.org/";
+
+// Announced by the external-link icon. MUI's `SvgIcon` marks itself
+// `aria-hidden` unless given `titleAccess`, so without this the "opens in a
+// new tab" cue would reach sighted users only.
+export const EXTERNAL_LINK_TITLE = "(opens in a new tab)";

--- a/components/HCABioNetworks/Network/Atlas/components/SourceDatasets/components/MainColumn/components/table/components/FileNameCell/fileNameCell.styles.ts
+++ b/components/HCABioNetworks/Network/Atlas/components/SourceDatasets/components/MainColumn/components/table/components/FileNameCell/fileNameCell.styles.ts
@@ -2,9 +2,20 @@ import { OpenInNewIcon } from "@databiosphere/findable-ui/lib/components/common/
 import styled from "@emotion/styled";
 
 /**
+ * Holds the citation's final word and the external-link icon on one line. A
+ * browser may break before an atomic inline box, which would otherwise strand
+ * the icon on a line of its own when the citation wraps.
+ */
+export const StyledNoWrap = styled.span`
+  white-space: nowrap;
+`;
+
+/**
  * External-link affordance for the citation line. Inline so it flows with the
- * citation text and shares its colour via `currentColor`, and vertically
- * centred against the smaller secondary line without adding to its height.
+ * citation text and shares its colour via `currentColor`. The size is set with
+ * the `fontSize` prop at the call site rather than here: the theme's
+ * `MuiSvgIcon-fontSizeXsmall` variant wins over a `font-size` declaration in
+ * this block, so styling it here silently has no effect.
  */
 export const StyledOpenInNewIcon = styled(OpenInNewIcon)`
   margin-left: 4px;

--- a/components/HCABioNetworks/Network/Atlas/components/SourceDatasets/components/MainColumn/components/table/components/FileNameCell/fileNameCell.styles.ts
+++ b/components/HCABioNetworks/Network/Atlas/components/SourceDatasets/components/MainColumn/components/table/components/FileNameCell/fileNameCell.styles.ts
@@ -1,0 +1,12 @@
+import { OpenInNewIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/OpenInNewIcon/openInNewIcon";
+import styled from "@emotion/styled";
+
+/**
+ * External-link affordance for the citation line. Inline so it flows with the
+ * citation text and shares its colour via `currentColor`, and vertically
+ * centred against the smaller secondary line without adding to its height.
+ */
+export const StyledOpenInNewIcon = styled(OpenInNewIcon)`
+  margin-left: 4px;
+  vertical-align: middle;
+`;

--- a/components/HCABioNetworks/Network/Atlas/components/SourceDatasets/components/MainColumn/components/table/components/FileNameCell/fileNameCell.tsx
+++ b/components/HCABioNetworks/Network/Atlas/components/SourceDatasets/components/MainColumn/components/table/components/FileNameCell/fileNameCell.tsx
@@ -3,6 +3,7 @@ import {
   REL_ATTRIBUTE,
 } from "@databiosphere/findable-ui/lib/components/Links/common/entities";
 import { Link } from "@databiosphere/findable-ui/lib/components/Links/components/Link/link";
+import { SVG_ICON_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/svgIcon";
 import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
 import { Stack, Typography } from "@mui/material";
 import type { JSX } from "react";
@@ -45,7 +46,7 @@ export const FileNameCell = ({ row }: Props): JSX.Element => {
                   <StyledNoWrap>
                     {splitTrailingWord(publicationString).tail}
                     <StyledOpenInNewIcon
-                      fontSize="xxsmall"
+                      fontSize={SVG_ICON_PROPS.FONT_SIZE.XXSMALL}
                       titleAccess={EXTERNAL_LINK_TITLE}
                     />
                   </StyledNoWrap>

--- a/components/HCABioNetworks/Network/Atlas/components/SourceDatasets/components/MainColumn/components/table/components/FileNameCell/fileNameCell.tsx
+++ b/components/HCABioNetworks/Network/Atlas/components/SourceDatasets/components/MainColumn/components/table/components/FileNameCell/fileNameCell.tsx
@@ -7,6 +7,7 @@ import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/m
 import { Stack, Typography } from "@mui/material";
 import type { JSX } from "react";
 import { DOI_BASE_URL } from "./constants";
+import { StyledOpenInNewIcon } from "./fileNameCell.styles";
 import type { Props } from "./types";
 
 /**
@@ -35,12 +36,23 @@ export const FileNameCell = ({ row }: Props): JSX.Element => {
           component="div"
           variant={TYPOGRAPHY_PROPS.VARIANT.BODY_SMALL_400}
         >
-          <Link
-            label={publicationString}
-            rel={REL_ATTRIBUTE.NO_OPENER_NO_REFERRER}
-            target={ANCHOR_TARGET.BLANK}
-            url={doi ? `${DOI_BASE_URL}${doi}` : ""}
-          />
+          {doi ? (
+            // Text and icon are one label, so they are a single link target.
+            <Link
+              label={
+                <>
+                  {publicationString}
+                  <StyledOpenInNewIcon />
+                </>
+              }
+              rel={REL_ATTRIBUTE.NO_OPENER_NO_REFERRER}
+              target={ANCHOR_TARGET.BLANK}
+              url={`${DOI_BASE_URL}${doi}`}
+            />
+          ) : (
+            // No DOI, so no link and no external-link affordance.
+            publicationString
+          )}
         </Typography>
       )}
     </Stack>

--- a/components/HCABioNetworks/Network/Atlas/components/SourceDatasets/components/MainColumn/components/table/components/FileNameCell/fileNameCell.tsx
+++ b/components/HCABioNetworks/Network/Atlas/components/SourceDatasets/components/MainColumn/components/table/components/FileNameCell/fileNameCell.tsx
@@ -6,9 +6,11 @@ import { Link } from "@databiosphere/findable-ui/lib/components/Links/components
 import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
 import { Stack, Typography } from "@mui/material";
 import type { JSX } from "react";
-import { DOI_BASE_URL } from "./constants";
-import { StyledOpenInNewIcon } from "./fileNameCell.styles";
+import { buildVersionedFileNameValue } from "../../accessor";
+import { DOI_BASE_URL, EXTERNAL_LINK_TITLE } from "./constants";
+import { StyledNoWrap, StyledOpenInNewIcon } from "./fileNameCell.styles";
 import type { Props } from "./types";
+import { splitTrailingWord } from "./utils";
 
 /**
  * Pinned cell stacking the published file name over the source study citation.
@@ -19,12 +21,10 @@ import type { Props } from "./types";
  * @returns stacked file name and source study cell.
  */
 export const FileNameCell = ({ row }: Props): JSX.Element => {
-  const { baseFileName, datasetAsset, doi, publicationString } = row;
-  // `versionedFileName` is set for every tracker source dataset, but it is
-  // optional on the shared asset type - fall back to the unversioned base name
-  // so the pinned column, which identifies the row in the collapsed layout,
-  // can never render empty.
-  const fileName = datasetAsset?.versionedFileName || baseFileName;
+  const { doi, publicationString } = row;
+  // Shared with the column's `accessorFn`, so the pinned column always sorts on
+  // the value it displays.
+  const fileName = buildVersionedFileNameValue(row);
   return (
     <Stack spacing={2} useFlexGap>
       <Typography variant={TYPOGRAPHY_PROPS.VARIANT.BODY_400}>
@@ -41,12 +41,24 @@ export const FileNameCell = ({ row }: Props): JSX.Element => {
             <Link
               label={
                 <>
-                  {publicationString}
-                  <StyledOpenInNewIcon />
+                  {splitTrailingWord(publicationString).head}
+                  <StyledNoWrap>
+                    {splitTrailingWord(publicationString).tail}
+                    <StyledOpenInNewIcon
+                      fontSize="xxsmall"
+                      titleAccess={EXTERNAL_LINK_TITLE}
+                    />
+                  </StyledNoWrap>
                 </>
               }
               rel={REL_ATTRIBUTE.NO_OPENER_NO_REFERRER}
               target={ANCHOR_TARGET.BLANK}
+              // MUI `Link` defaults to `color="primary"` and findable-ui's
+              // theme does not override it, so the wrapper's `ink.light` is
+              // ignored unless the colour is set on the link itself.
+              TypographyProps={{
+                color: TYPOGRAPHY_PROPS.COLOR.INK_LIGHT,
+              }}
               url={`${DOI_BASE_URL}${doi}`}
             />
           ) : (

--- a/components/HCABioNetworks/Network/Atlas/components/SourceDatasets/components/MainColumn/components/table/components/FileNameCell/utils.ts
+++ b/components/HCABioNetworks/Network/Atlas/components/SourceDatasets/components/MainColumn/components/table/components/FileNameCell/utils.ts
@@ -1,0 +1,16 @@
+/**
+ * Splits text into its leading portion and its final word, so the final word
+ * can be held on one line with the external-link icon that follows it. A
+ * browser may break before an atomic inline box, which would otherwise leave
+ * the icon alone on the last line of a wrapped citation.
+ * @param text - Text to split.
+ * @returns leading text (including its trailing space) and the final word.
+ */
+export function splitTrailingWord(text: string): {
+  head: string;
+  tail: string;
+} {
+  const index = text.trimEnd().lastIndexOf(" ");
+  if (index === -1) return { head: "", tail: text };
+  return { head: text.slice(0, index + 1), tail: text.slice(index + 1) };
+}


### PR DESCRIPTION
## Summary

Closes #3196. Part of #3193.

The source study citation opens `https://doi.org/{doi}` in a new tab but rendered as plain link text with no signal that it leaves the site. This appends `OpenInNewIcon` to the citation label, and makes the no-DOI case explicit.

## Changes

- `FileNameCell/fileNameCell.tsx` — the citation now branches on `doi`. With a DOI, the `label` is a fragment of the citation text followed by the icon, so **text and icon are a single link target**. Without one, the citation renders as bare `Typography` text: no link, no icon.
- `FileNameCell/fileNameCell.styles.ts` — **new**, `StyledOpenInNewIcon` with `margin-left: 4px` and `vertical-align: middle`.

## Two deviations from the issue, both because #3195 landed first

1. **No `.ts` → `.tsx` rename.** #3196 says to rename `viewBuilder.ts` and compose the label there. #3195 moved that rendering into `FileNameCell.tsx`, which is already JSX, so there is nothing to rename — the issue anticipates this ("If #3195 moves this rendering into a dedicated cell component, apply the change there instead").
2. **`OpenInNewIcon` imported from findable-ui directly, not via `C.OpenInNewIcon`.** The AC names `components/index.tsx`, but that barrel only re-exports the same findable-ui component, and importing the barrel from a file *inside* `components/` to build a `styled()` wrapper risks an import cycle. Same component either way; the cell already imports `Link` from findable-ui directly, so this is consistent within the file.

## The no-DOI fix, and a correction to Copilot's review of #3208

Copilot flagged the pre-existing `url={doi ? … : ""}` on #3208 as rendering "a clickable DOI link with an empty URL … problematic for keyboard users". **That was not accurate** — findable-ui's `Link` already degrades an invalid URL to a plain span. Traced through `link.js` with `url=""`:

- `isURLString("")` → true (`typeof value === "string"`)
- `isClientSideNavigation("")` → false (`/^\/(?!\/)|^#/`)
- `isValidUrl("")` → false (`new URL("")` throws)

falling through to `<MTypography component="span">{label}</MTypography>`. No anchor, no `href`, nothing focusable — and `href=""` appears nowhere in the generated output.

The underlying point still stood, though: the cell was *relying* on that fallback instead of saying what it meant. This PR removes the `url=""` pattern entirely, which #3196 asked for independently and which is required here anyway — the icon must not render without a DOI.

## Verification

Against the built page for Breast v1.0:

- **7 DOI anchors, all 7 containing an `<svg>`** — so every citation link carries the icon, and it is inside the anchor rather than beside it. Sample, tags collapsed: `<a>Gray (2022) Developmental Cell<svg><path></path></svg></a>`
- `target="_blank"` and `rel="noopener noreferrer"` on all 7
- **`href=""` count: 0**
- Icon colour needs no styling — `OpenInNewIcon` renders `fill="currentColor"`, so it inherits `ink.light` from the citation `Typography`, and defaults to `fontSize="xsmall"`
- Alignment and row height confirmed visually in the browser at desktop width
- `npm run lint` (0 errors), `npm run check-format`, `npx tsc --noEmit`, `npm run build-prod:data-portal` (64/64) all pass

## Not verifiable with live data

Breast v1.0 carries a DOI on all seven source datasets, so the no-DOI branch cannot be exercised against the real tracker. Its behaviour is asserted from the code (`doi` falsy → bare `Typography`, no `Link`, no icon) rather than observed — flagging that rather than implying it was tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="876" height="996" alt="image" src="https://github.com/user-attachments/assets/9ddcc863-53dc-4873-ad22-e5a720c19ca4" />

