### PR TITLE
refactor: split the citation once in filenamecell (#3196)

### DIFF
--- a/components/HCABioNetworks/Network/Atlas/components/SourceDatasets/components/MainColumn/components/table/components/FileNameCell/fileNameCell.tsx
+++ b/components/HCABioNetworks/Network/Atlas/components/SourceDatasets/components/MainColumn/components/table/components/FileNameCell/fileNameCell.tsx
@@ -26,12 +26,16 @@ export const FileNameCell = ({ row }: Props): JSX.Element => {
   // Shared with the column's `accessorFn`, so the pinned column always sorts on
   // the value it displays.
   const fileName = buildVersionedFileNameValue(row);
+  // Split once - the final word is held on one line with the icon that follows.
+  const citation = publicationString
+    ? splitTrailingWord(publicationString)
+    : null;
   return (
     <Stack spacing={2} useFlexGap>
       <Typography variant={TYPOGRAPHY_PROPS.VARIANT.BODY_400}>
         {fileName}
       </Typography>
-      {publicationString && (
+      {citation && (
         <Typography
           color={TYPOGRAPHY_PROPS.COLOR.INK_LIGHT}
           component="div"
@@ -42,9 +46,9 @@ export const FileNameCell = ({ row }: Props): JSX.Element => {
             <Link
               label={
                 <>
-                  {splitTrailingWord(publicationString).head}
+                  {citation.head}
                   <StyledNoWrap>
-                    {splitTrailingWord(publicationString).tail}
+                    {citation.tail}
                     <StyledOpenInNewIcon
                       fontSize={SVG_ICON_PROPS.FONT_SIZE.XXSMALL}
                       titleAccess={EXTERNAL_LINK_TITLE}


### PR DESCRIPTION
## Summary

Small follow-up cleanup to #3196 (#3209), which has merged.

`FileNameCell` called `splitTrailingWord(publicationString)` twice in the JSX — once for `.head`, once for `.tail` — so the same string was split twice per row to render one citation.

```diff
+  const citation = publicationString
+    ? splitTrailingWord(publicationString)
+    : null;
 …
-      {publicationString && (
+      {citation && (
 …
-                  {splitTrailingWord(publicationString).head}
+                  {citation.head}
                   <StyledNoWrap>
-                    {splitTrailingWord(publicationString).tail}
+                    {citation.tail}
```

The split now also drives the citation's presence check, so `publicationString` is tested in one place rather than two.

## Why its own PR

The file is on `main` via #3209, and #3199 (Primary Data column) deliberately doesn't touch it — we'd just finished unpicking unrelated changes that had drifted onto that branch, so folding this in would have repeated the mistake for a five-line cleanup.

## Verification

Rendered output is unchanged: 7 DOI anchors, 7 `nowrap` spans each wrapping the final word plus its `<svg>`, and 7 `(opens in a new tab)` titles.

`npm run lint` (0 errors), `npm run check-format`, `npx tsc --noEmit`, `npm run build-prod:data-portal` (64/64) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)