### PR TITLE
refactor: render viewmodelbuilders cells as elements (#3211)

### DIFF
--- a/viewModelBuilders/viewModelBuilders.tsx
+++ b/viewModelBuilders/viewModelBuilders.tsx
@@ -1,10 +1,16 @@
 import { LABEL } from "@databiosphere/findable-ui/lib/apis/azul/common/entities";
+import { CookieBanner } from "@databiosphere/findable-ui/lib/components/common/Banner/components/CookieBanner/cookieBanner";
 import { KeyValues } from "@databiosphere/findable-ui/lib/components/common/KeyValuePairs/keyValuePairs";
 import {
   ANCHOR_TARGET,
   REL_ATTRIBUTE,
 } from "@databiosphere/findable-ui/lib/components/Links/common/entities";
-import { MetadataValue } from "@databiosphere/findable-ui/lib/components/Table/components/TableCell/components/NTagCell/nTagCell";
+import { Link } from "@databiosphere/findable-ui/lib/components/Links/components/Link/link";
+import { BasicCell } from "@databiosphere/findable-ui/lib/components/Table/components/TableCell/components/BasicCell/basicCell";
+import {
+  MetadataValue,
+  NTagCell,
+} from "@databiosphere/findable-ui/lib/components/Table/components/TableCell/components/NTagCell/nTagCell";
 import { ColumnDef } from "@tanstack/react-table";
 import type { JSX } from "react";
 import type {
@@ -21,8 +27,15 @@ import {
   processAggregatedOrArrayValue,
   processEntityValue,
 } from "../apis/azul/hca-dcp/common/utils";
-import * as C from "../components";
-import { MetadataValueTuple } from "../components/common/NTagCell/components/PinnedNTagCell/pinnedNTagCell";
+import { ButtonOutline } from "../components/common/Button/components/ButtonOutline/buttonOutline";
+import {
+  MetadataValueTuple,
+  PinnedNTagCell,
+} from "../components/common/NTagCell/components/PinnedNTagCell/pinnedNTagCell";
+import { BioNetworkCell } from "../components/common/Table/components/Cell/components/BioNetworkCell/bioNetworkCell";
+import { CXGDownloadCell } from "../components/common/Table/components/Cell/components/CXGDownloadCell/cxgDownloadCell";
+import { TrackerDownloadCell } from "../components/common/Table/components/Cell/components/TrackerDownloadCell/trackerDownloadCell";
+import { AnalysisPortalCell } from "../components/HCABioNetworks/Network/Atlas/components/Overview/components/MainColumn/components/AnalysisPortalCell/analysisPortalCell";
 import { NETWORKS_ROUTE } from "../constants/routes";
 import { formatCountSize } from "../utils/formatCountSize";
 import { buildTrackerDownloadCellProps } from "../utils/trackerNetwork";
@@ -48,23 +61,27 @@ export function accumulateValues(
  * @returns model to be used as props for the CookieBanner component.
  */
 export const buildCookieBanner = (): React.ComponentProps<
-  typeof C.CookieBanner
+  typeof CookieBanner
 > => {
   return {
     localStorageKey: "privacy-accepted",
     message:
       "This website uses cookies for security and analytics purposes. By using this site, you agree to these uses.",
-    secondaryAction: C.ButtonOutline({
-      children: "Learn More",
-      /* eslint-disable sonarjs/link-with-target-blank -- rule doesn't recognize constant */
-      onClick: () =>
-        window.open(
-          "https://data.humancellatlas.org/privacy",
-          ANCHOR_TARGET.BLANK,
-          REL_ATTRIBUTE.NO_OPENER_NO_REFERRER
-        ),
-      /* eslint-enable sonarjs/link-with-target-blank -- keep checking future noopener cases */
-    }),
+    secondaryAction: (
+      <ButtonOutline
+        /* eslint-disable sonarjs/link-with-target-blank -- rule doesn't recognize constant */
+        onClick={() =>
+          window.open(
+            "https://data.humancellatlas.org/privacy",
+            ANCHOR_TARGET.BLANK,
+            REL_ATTRIBUTE.NO_OPENER_NO_REFERRER
+          )
+        }
+        /* eslint-enable sonarjs/link-with-target-blank -- keep checking future noopener cases */
+      >
+        Learn More
+      </ButtonOutline>
+    ),
   };
 };
 
@@ -103,13 +120,14 @@ function getAtlasesActionsColumnDef(
             row.original.datasetAssets[0]
           );
           if (!props) return null;
-          return C.TrackerDownloadCell(props);
+          return <TrackerDownloadCell {...props} />;
         }
-      : ({ row }): JSX.Element =>
-          C.CXGDownloadCell({
-            datasetAssets: row.original.datasetAssets,
-            title: row.original.name,
-          }),
+      : ({ row }): JSX.Element => (
+          <CXGDownloadCell
+            datasetAssets={row.original.datasetAssets}
+            title={row.original.name}
+          />
+        ),
     header: "Download",
   };
 }
@@ -121,8 +139,7 @@ function getAtlasesActionsColumnDef(
 function getAtlasesAssayColumnDef<T extends AtlasRow>(): ColumnDef<T> {
   return {
     accessorKey: "assay",
-    cell: ({ row }) =>
-      C.NTagCell({ label: "assays", values: row.original.assay }),
+    cell: ({ row }) => <NTagCell label="assays" values={row.original.assay} />,
     header: "Assay",
   };
 }
@@ -137,11 +154,12 @@ function getAtlasesAtlasNameColumnDef(
 ): ColumnDef<AtlasesRow> {
   return {
     accessorKey: "atlasName",
-    cell: ({ row }) =>
-      C.Link({
-        label: row.original.atlasName,
-        url: `${NETWORKS_ROUTE}/${networkPath}/atlases/${row.original.path}`,
-      }),
+    cell: ({ row }) => (
+      <Link
+        label={row.original.atlasName}
+        url={`${NETWORKS_ROUTE}/${networkPath}/atlases/${row.original.path}`}
+      />
+    ),
     header: "Atlas Name",
   };
 }
@@ -165,14 +183,15 @@ function getAtlasesCellCountColumnDef<T extends AtlasRow>(): ColumnDef<T> {
 function getAtlasesDiseaseColumnDef<T extends AtlasRow>(): ColumnDef<T> {
   return {
     accessorKey: "disease",
-    cell: ({ row }) =>
-      C.PinnedNTagCell({
-        label: "diseases",
-        values: partitionMetadataValues(
+    cell: ({ row }) => (
+      <PinnedNTagCell
+        label="diseases"
+        values={partitionMetadataValues(
           [...row.original.disease],
           [DISEASE.NORMAL]
-        ),
-      }),
+        )}
+      />
+    ),
     header: "Disease",
   };
 }
@@ -186,8 +205,9 @@ function getAtlasesExploreColumnDef<
 >(): ColumnDef<T> {
   return {
     accessorKey: "explore",
-    cell: ({ row }) =>
-      C.AnalysisPortalCell({ analysisPortals: row.original.analysisPortals }),
+    cell: ({ row }) => (
+      <AnalysisPortalCell analysisPortals={row.original.analysisPortals} />
+    ),
     header: "Explore",
   };
 }
@@ -216,8 +236,9 @@ export function getAtlasesTableColumns(
 function getAtlasesTissueColumnDef<T extends AtlasRow>(): ColumnDef<T> {
   return {
     accessorKey: "tissue",
-    cell: ({ row }) =>
-      C.NTagCell({ label: "tissues", values: row.original.tissue }),
+    cell: ({ row }) => (
+      <NTagCell label="tissues" values={row.original.tissue} />
+    ),
     header: "Tissue",
   };
 }
@@ -238,7 +259,7 @@ export function getBioNetworkName(name: string): string {
 function getBioNetworksAtlasesColumnDef(): ColumnDef<Network> {
   return {
     accessorKey: "atlases",
-    cell: ({ row }) => C.BasicCell({ value: row.original.atlases.length }),
+    cell: ({ row }) => <BasicCell value={row.original.atlases.length} />,
     header: "Atlases",
   };
 }
@@ -250,7 +271,7 @@ function getBioNetworksAtlasesColumnDef(): ColumnDef<Network> {
 function getBioNetworksNetworkNameColumnDef(): ColumnDef<Network> {
   return {
     accessorKey: "networkName",
-    cell: ({ row }) => C.BioNetworkCell({ network: row.original }),
+    cell: ({ row }) => <BioNetworkCell network={row.original} />,
     header: "HCA Biological Network Atlas",
   };
 }
@@ -273,14 +294,15 @@ export function getBioNetworksTableColumns(): ColumnDef<Network>[] {
 function getDonorDiseaseColumnDef(): ColumnDef<ProjectsResponse> {
   return {
     accessorKey: "disease",
-    cell: ({ row }) =>
-      C.PinnedNTagCell({
-        label: "diseases",
-        values: partitionMetadataValues(
+    cell: ({ row }) => (
+      <PinnedNTagCell
+        label="diseases"
+        values={partitionMetadataValues(
           processAggregatedOrArrayValue(row.original.donorOrganisms, "disease"),
           [DISEASE.NORMAL]
-        ),
-      }),
+        )}
+      />
+    ),
     header: "Disease (Donor)",
   };
 }
@@ -320,8 +342,9 @@ export function getEstimatedCellCount(
 function getEstimateCellCountColumnDef(): ColumnDef<ProjectsResponse> {
   return {
     accessorKey: "estimatedCellCount",
-    cell: ({ row }) =>
-      C.BasicCell({ value: getEstimatedCellCount(row.original) }),
+    cell: ({ row }) => (
+      <BasicCell value={getEstimatedCellCount(row.original)} />
+    ),
     header: "Cell Count Est.",
   };
 }
@@ -333,14 +356,15 @@ function getEstimateCellCountColumnDef(): ColumnDef<ProjectsResponse> {
 function getGenusSpeciesColumnDef(): ColumnDef<ProjectsResponse> {
   return {
     accessorKey: "genusSpecies",
-    cell: ({ row }) =>
-      C.NTagCell({
-        label: "species",
-        values: processAggregatedOrArrayValue(
+    cell: ({ row }) => (
+      <NTagCell
+        label="species"
+        values={processAggregatedOrArrayValue(
           row.original.donorOrganisms,
           "genusSpecies"
-        ),
-      }),
+        )}
+      />
+    ),
     header: "Species",
   };
 }
@@ -352,7 +376,7 @@ function getGenusSpeciesColumnDef(): ColumnDef<ProjectsResponse> {
 function getIntegratedAtlasesAtlasNameColumnDef(): ColumnDef<IntegratedAtlasRow> {
   return {
     accessorKey: "name",
-    cell: ({ row }) => C.BasicCell({ value: row.original.name }),
+    cell: ({ row }) => <BasicCell value={row.original.name} />,
     header: "Atlas Name",
   };
 }
@@ -387,14 +411,15 @@ export function getIntegratedAtlasesTableColumns(
 function getLibraryConstructionMethodColumnDef(): ColumnDef<ProjectsResponse> {
   return {
     accessorKey: "libraryConstructionApproach",
-    cell: ({ row }) =>
-      C.NTagCell({
-        label: "library construction methods",
-        values: processAggregatedOrArrayValue(
+    cell: ({ row }) => (
+      <NTagCell
+        label="library construction methods"
+        values={processAggregatedOrArrayValue(
           row.original.protocols,
           "libraryConstructionApproach"
-        ),
-      }),
+        )}
+      />
+    ),
     header: "Method",
   };
 }
@@ -478,12 +503,13 @@ function getProjectTitleColumnDef(
 ): ColumnDef<ProjectsResponse> {
   return {
     accessorKey: "projectTitle",
-    cell: ({ row }) =>
-      C.Link({
-        label: processEntityValue(row.original.projects, "projectTitle"),
-        target: ANCHOR_TARGET.BLANK,
-        url: getProjectTitleUrl(row.original, browserURL),
-      }),
+    cell: ({ row }) => (
+      <Link
+        label={processEntityValue(row.original.projects, "projectTitle")}
+        target={ANCHOR_TARGET.BLANK}
+        url={getProjectTitleUrl(row.original, browserURL)}
+      />
+    ),
     header: "Project Title",
   };
 }
@@ -518,11 +544,12 @@ function getProjectTitleUrl(
 function getSpecimenOrganColumnDef(): ColumnDef<ProjectsResponse> {
   return {
     accessorKey: "organ",
-    cell: ({ row }) =>
-      C.NTagCell({
-        label: "anatomical entities",
-        values: processAggregatedOrArrayValue(row.original.specimens, "organ"),
-      }),
+    cell: ({ row }) => (
+      <NTagCell
+        label="anatomical entities"
+        values={processAggregatedOrArrayValue(row.original.specimens, "organ")}
+      />
+    ),
     header: "Anatomical Entity",
   };
 }


### PR DESCRIPTION
## Summary

Closes #3211.

`viewModelBuilders.ts` built table cells by invoking components as plain functions — `C.NTagCell({ … })` rather than `<NTagCell … />` — across 17 call sites. That inlines the component body into whichever component renders the cell, so there is no component instance and no reconciliation boundary: hooks, context, `memo` and refs don't behave as they would for a real element.

**Two of those components use hooks.** `TrackerDownloadCell` and `CXGDownloadCell` both call `useDialog()`, so their hooks were attaching to the enclosing renderer's hook list. It held only because each cell renderer runs unconditionally and the cell count is stable — the same latent hazard that was fixed for the tracker source datasets table in #3195.

## Changes

- **Renamed** `viewModelBuilders/viewModelBuilders.ts` → `.tsx`. Every consumer imports it extensionless, so no import statement anywhere needed changing.
- **All 17 cell renderers now return elements.** `TrackerDownloadCell` and `CXGDownloadCell` (the two with hooks) plus `NTagCell` ×5, `PinnedNTagCell` ×2, `BasicCell` ×3, `Link` ×2, `AnalysisPortalCell`, `BioNetworkCell`, and the `ButtonOutline` in `buildCookieBanner`.
- **Dropped the `import * as C` barrel** for direct imports — four from findable-ui (`CookieBanner`, `Link`, `BasicCell`, `NTagCell`) and six local (`ButtonOutline`, `PinnedNTagCell`, `BioNetworkCell`, `CXGDownloadCell`, `TrackerDownloadCell`, `AnalysisPortalCell`).

## Verification

This file drives more than the atlas pages, so I compared the **whole** static export before and after rather than spot-checking.

Captured a structural fingerprint of all 63 exported pages on both `main` and this branch — download-button count, chip count, the full set of anchor `href`s and the full set of `<img src>`s per page:

```
pages before/after: 63 / 63
pages with structural differences: 0
```

**Identical across every page** — every link target, every image, every download button and every N-tag chip. Surfaces exercised: the tracker atlas overview (integrated objects, CAP portal links), the non-tracker atlas `/datasets` page (Azul projects table, 49 chips), the network atlases tables, the bio-networks list, and the home page.

Note I compared *content* rather than file hashes deliberately: **this build is not byte-deterministic** — identical code produces different HTML hashes between runs, so hash comparison reports false differences.

`npm run lint` (0 errors), `npm run check-format`, `npx tsc --noEmit`, `npm run build-prod:data-portal` (64/64) all pass.

## No conflicts

Checked all 41 open PRs before starting: none touches `viewModelBuilders`, which matters because the `.ts` → `.tsx` rename would conflict with any concurrent edit to the file. #3213 and #3214 touch the source datasets table only.

## Not a repo-wide sweep - 6 sites remain, filed as #3217

This PR fixes `viewModelBuilders` only. A full audit afterwards found **6 more component-as-function calls**, all in `site-config/data-portal/dev/config.ts`:

| Line | Call |
| --- | --- |
| 87 | `Branding: C.Logo({…})` |
| 117 | `logo: C.Logo({…})` |
| 184, 188, 192, 196 | `icon: C.GitHubIcon / FacebookIcon / XIcon / LinkedInIcon({ fontSize: "small" })` |

**They are benign, for two reasons that don't apply to this PR's sites.** None of those five components uses a hook, so there is no hook-ordering hazard — unlike `TrackerDownloadCell` and `CXGDownloadCell` here, which both call `useDialog()`. And they run at **module scope** rather than during a render, so they are a different shape of problem: elements built eagerly at import time and stored in config, not components inlined into a parent's render.

Filed as #3217 because "config constructs elements eagerly" is a pattern worth a deliberate decision rather than being quietly converted — it also constrains those components to stay hook-free, which nothing currently enforces.

Four other modules still import the `C` barrel and want the same audit: `mdx-components.tsx`, `docs/common/constants.ts`, `site-config/data-portal/dev/socialMedia.ts`, `site-config/data-portal/dev/layout/floating.ts`. A sweep for non-barrel direct calls (`PascalCase({ … })` in `.ts`, `return PascalCase({ … })` in `.tsx`) came back clean.

## One fix worth noting

The `CXGDownloadCell` conversion needed parentheses added around the JSX in a concise arrow body — the original `=> C.CXGDownloadCell({…})` had its closing paren belonging to the call, so converting the call without adding the wrapper left an unbalanced paren. `tsc` caught it immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
