### PR TITLE
fix: point the breast atlas code link at the current ihbca repo (#3221)

### DIFF
--- a/constants/networks.ts
+++ b/constants/networks.ts
@@ -62,8 +62,8 @@ export const NETWORKS: Network[] = [
       {
         code: [
           {
-            label: "https://github.com/NoahWex/iHBCA_v1",
-            url: "https://github.com/NoahWex/iHBCA_v1",
+            label: "https://github.com/NoahWex/iHBCAv1_cap",
+            url: "https://github.com/NoahWex/iHBCAv1_cap",
           },
         ],
         coordinators: [


### PR DESCRIPTION
## Summary

Closes #3221.

The breast atlas overview page linked its **Code** reference at `NoahWex/iHBCA_v1`. The atlas code now lives at `NoahWex/iHBCAv1_cap`.

```diff
 code: [
   {
-    label: "https://github.com/NoahWex/iHBCA_v1",
-    url: "https://github.com/NoahWex/iHBCA_v1",
+    label: "https://github.com/NoahWex/iHBCAv1_cap",
+    url: "https://github.com/NoahWex/iHBCAv1_cap",
   },
 ],
```

Both lines change together because the `label` *is* the URL for this field — changing only `url` would leave the visible text pointing somewhere it doesn't go.

## Why this is the right target

Checked both repos against the GitHub API rather than taking the issue's word for it:

| | `iHBCA_v1` (old) | `iHBCAv1_cap` (new) |
| --- | --- | --- |
| Public | yes | yes |
| Description | *(none)* | "Integrated Human Breast Cell Atlas (iHBCA) v1.0: assembly, harmonization, and validation code" |
| Last updated | 2026-06-18 | 2026-09-09 |

Both resolve `HTTP 200`, so this was never a broken link — it just pointed at the wrong place. The new repo's description matches the atlas exactly and it is actively maintained; the old one carries no description and has been untouched since June.

## Verification

- Rendered on `/hca-bio-networks/breast/atlases/breast-v1`, under the **Code** heading in the overview side column: **1** anchor to the new URL, **0** to the old.
- Swept the whole export: the old URL appears on **no** page.
- `grep -rn "iHBCA_v1"` across the repo returns nothing.
- `npm run lint` (0 errors), `npm run check-format`, `npx tsc --noEmit`, `npm run build-prod:data-portal` (64/64) all pass.

## One thing worth a second pair of eyes

#3221 flags that this is the portal's public front door for that link, and suggests confirming with the breast coordinators that `iHBCAv1_cap` is the repo they want surfaced — rather than a working repo they would prefer stayed internal.

I haven't been able to confirm that directly. The evidence above is strong, and **Noah Wechter is both the repo owner and the atlas coordinator listed in `constants/networks.ts` (`nwechter@uci.edu`)**, so this review is a reasonable checkpoint — but if there is any doubt, worth a message before merging rather than after.

## Interaction with #3220

None. #3220 renames the atlas *path* (`breast-v1` → `breast-v1-0`); this touches the `code` entry. Different lines of `constants/networks.ts`, so either can land first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)